### PR TITLE
Update cosmos fetch to accomodate and take advantage of API updates

### DIFF
--- a/client/src/components/SimilarDocs.vue
+++ b/client/src/components/SimilarDocs.vue
@@ -55,7 +55,7 @@
 
     async getSimilar (doi: string): Promise<void> {
       if (doi) {
-        const response = await cosmosSimilar(doi);
+        const response = await cosmosSimilar({ doi });
         response.data.map(similarDoc => {
           similarDoc.objects = similarDoc.objects.filter(object => object.bytes !== null).slice(0, ARTIFACT_LIMIT);
           return similarDoc;

--- a/client/src/services/CosmosFetchService.ts
+++ b/client/src/services/CosmosFetchService.ts
@@ -47,8 +47,8 @@ export const cosmosArtifactsMem = async (paramObj: {doi: string}): Promise<Cosmo
 const COSMOS_SIMILAR_URL = 'https://xdd.wisc.edu/sets/xdd-covid-19/doc2vec/api/similar';
 
 // eslint-disable-next-line camelcase
-export const cosmosSimilar = async (doi: string): Promise<CosmosSimilarInterface> => {
-  const similarList = await getUtilMem(COSMOS_SIMILAR_URL, { api_key: COSMOS_API_KEY, doi });
+export const cosmosSimilar = async (paramObj: {doi: string}): Promise<CosmosSimilarInterface> => {
+  const similarList = await getUtilMem(COSMOS_SIMILAR_URL, { api_key: COSMOS_API_KEY, ...paramObj });
   await Promise.all(similarList.data.map(async (similar, index) => {
     const response = await cosmosArtifactsMem({ doi: similar.bibjson.identifier[0].id });
     similarList.data[index].objects = response.objects;


### PR DESCRIPTION
This restores normal operation of cosmos fetch functions which was broken by the cosmos API update requiring `api_key` for all endpoints. In addition this updates the `cosmosArtifactsMem` to take advantage of the new feature added by cosmos providing image data in the `/sets/xdd-covid-19/cosmos/api/document` endpoint, which results in loading times of knowledge modals being cut by more than half.

To test, check that the loading times of panels and modals in knowledge are drastically reduced and check that all features using the cosmos API are operating normally.