### PR TITLE
Models metadata collapsible items always take up all vertical space

### DIFF
--- a/client/src/components/Collapsible/CollapsibleContainer.vue
+++ b/client/src/components/Collapsible/CollapsibleContainer.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="collapsible-container">
+    <template v-if="!isEmpty">
+      <slot name="item"/>
+    </template>
+
+    <slot v-else name="empty"/>
+  </div>
+</template>
+
+<script lang="ts">
+  import Component from 'vue-class-component';
+  import Vue from 'vue';
+  import { Prop } from 'vue-property-decorator';
+
+  @Component
+  export default class CollapsibleContainer extends Vue {
+    @Prop({ default: false }) isEmpty: any;
+  }
+</script>
+
+<style lang="scss" scoped>
+@import "@/styles/variables";
+
+.collapsible-container {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+</style>

--- a/client/src/components/Collapsible/CollapsibleItem.vue
+++ b/client/src/components/Collapsible/CollapsibleItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="collapsible-container">
+  <div class="collapsible-item">
     <div class="item-container">
       <div
         class="item-title"
@@ -63,7 +63,7 @@
 
 <style lang="scss">
 @import "@/styles/variables";
-.collapsible-container {
+.collapsible-item {
   margin: 2px 0;
   display: flex;
   flex-direction: column;

--- a/client/src/views/Models/Bio/components/DrilldownPanel/EdgePane.vue
+++ b/client/src/views/Models/Bio/components/DrilldownPanel/EdgePane.vue
@@ -1,27 +1,26 @@
 <template>
-  <div class="edge-pane-container">
-    <div v-if="!isEmptyMetadata">
-      <collapsible-item key="tested">
-        <div slot="title">Tested</div>
-        <div slot="content" class="my-3">{{data.tested}}</div>
-      </collapsible-item>
-      <collapsible-item key="belief">
-        <div slot="title">Belief</div>
-        <div slot="content" class="my-3">{{data.belief}}</div>
-      </collapsible-item>
-      <collapsible-item key="evidence">
-        <div slot="title">Evidence</div>
-        <div slot="content" class="my-3">
-          <ul class="pl-4">
-            <li v-for="(evidence, index) in data.evidence" :key="index">{{evidence.text}}</li>
-          </ul>
-        </div>
-      </collapsible-item>
-    </div>
-    <div v-else class="alert alert-info" role="alert">
+  <collapsible-container :isEmpty="isEmptyMetadata">
+    <collapsible-item slot="item">
+      <div slot="title">Tested</div>
+      <div slot="content" class="my-3">{{data.tested}}</div>
+    </collapsible-item>
+    <collapsible-item slot="item">
+      <div slot="title">Belief</div>
+      <div slot="content" class="my-3">{{data.belief}}</div>
+    </collapsible-item>
+    <collapsible-item class="flex-grow-1" slot="item">
+      <div slot="title">Evidence</div>
+      <div slot="content" class="h-100 position-absolute">
+        <ul class="pl-4 h-100 overflow-auto">
+          <li v-for="(evidence, index) in data.evidence" :key="index">{{evidence.text}}</li>
+        </ul>
+      </div>
+    </collapsible-item>
+
+    <div slot="empty" class="alert alert-info" role="alert">
       No metadata at the moment
     </div>
-  </div>
+  </collapsible-container>
 </template>
 
 <script lang="ts">
@@ -30,9 +29,11 @@
   import Component from 'vue-class-component';
   import Vue from 'vue';
   import { Prop } from 'vue-property-decorator';
-  import CollapsibleItem from '@/components/CollapsibleItem.vue';
+  import CollapsibleContainer from '@/components/Collapsible/CollapsibleContainer.vue';
+  import CollapsibleItem from '@/components/Collapsible/CollapsibleItem.vue';
 
   const components = {
+    CollapsibleContainer,
     CollapsibleItem,
   };
 

--- a/client/src/views/Models/Bio/components/DrilldownPanel/NodePane.vue
+++ b/client/src/views/Models/Bio/components/DrilldownPanel/NodePane.vue
@@ -1,22 +1,21 @@
 <template>
-  <div class="node-pane-container">
-    <div v-if="!isEmptyMetadata">
-      <collapsible-item v-for="(values, dataObjectKey) in dataObject" :key="dataObjectKey">
-        <div slot="title">{{dataObjectKey}}</div>
-        <div v-if="dataObjectKey !== 'DBRefs'">
-          <div slot="content" class="mb-1 px-2 py-2 d-flex rounded-lg border" role="button" v-for="(edge, index) in values" :key="index" @click="onEdgeClick(edge)">
-            {{edge.source_label}} → {{edge.target_label}}
-          </div>
+  <collapsible-container :isEmpty="isEmptyMetadata">
+    <collapsible-item slot="item" v-for="(values, dataObjectKey) in dataObject" :key="dataObjectKey">
+      <div slot="title">{{dataObjectKey}}</div>
+      <div v-if="dataObjectKey !== 'DBRefs'">
+        <div slot="content" class="mb-1 px-2 py-2 d-flex rounded-lg border" role="button" v-for="(edge, index) in values" :key="index" @click="onEdgeClick(edge)">
+          {{edge.source_label}} → {{edge.target_label}}
         </div>
-        <div v-else slot="content">
-          {{values}}
-        </div>
-      </collapsible-item>
-    </div>
-    <div v-else class="alert alert-info" role="alert">
+      </div>
+      <div v-else slot="content">
+        {{values}}
+      </div>
+    </collapsible-item>
+
+    <div slot="empty" class="alert alert-info" role="alert">
       No metadata at the moment
     </div>
-  </div>
+  </collapsible-container>
 </template>
 
 <script lang="ts">
@@ -26,9 +25,11 @@
   import Vue from 'vue';
   import { Prop } from 'vue-property-decorator';
 
-  import CollapsibleItem from '@/components/CollapsibleItem.vue';
+  import CollapsibleContainer from '@/components/Collapsible/CollapsibleContainer.vue';
+  import CollapsibleItem from '@/components/Collapsible/CollapsibleItem.vue';
 
   const components = {
+    CollapsibleContainer,
     CollapsibleItem,
   };
 

--- a/client/src/views/Models/Epi/components/DrilldownPanel/KnowledgePane.vue
+++ b/client/src/views/Models/Epi/components/DrilldownPanel/KnowledgePane.vue
@@ -23,14 +23,9 @@
   import Vue from 'vue';
   import { Prop } from 'vue-property-decorator';
 
-  import CollapsibleItem from '@/components/CollapsibleItem.vue';
   import { CosmosSearchInterface } from '@/types/typesCosmos';
 
-  const components = {
-    CollapsibleItem,
-  };
-
-  @Component({ components })
+  @Component
   export default class KnowledgePane extends Vue {
     @Prop({ default: null }) data: CosmosSearchInterface;
 

--- a/client/src/views/Models/Epi/components/DrilldownPanel/MetadataPane.vue
+++ b/client/src/views/Models/Epi/components/DrilldownPanel/MetadataPane.vue
@@ -1,19 +1,18 @@
 <template>
-  <div class="metadata-pane-container">
-    <template v-if="!isEmptyMetadata">
-      <collapsible-item>
-        <div slot="title">Type</div>
-        <div slot="content">
-          <div class="metadata-item">
-              {{getType}}
-          </div>
+  <collapsible-container :isEmpty="isEmptyMetadata">
+    <collapsible-item slot="item">
+      <div slot="title">Type</div>
+      <div slot="content">
+        <div class="metadata-item">
+            {{getType}}
         </div>
-      </collapsible-item>
+      </div>
+    </collapsible-item>
 
-      <collapsible-item>
-        <div slot="title">Provenance</div>
-        <div slot="content">
-          <div class="metadata-item">
+    <collapsible-item slot="item">
+      <div slot="title">Provenance</div>
+      <div slot="content">
+        <div class="metadata-item">
           <div v-for="(value, key) in getProvenance" :key="key">
             <div class="key">{{key | capitalize-first-letter-formatter}}</div>
             <div v-if="key !== 'sources'">{{value}}</div>
@@ -24,12 +23,12 @@
             </div>
           </div>
         </div>
-        </div>
-      </collapsible-item>
+      </div>
+    </collapsible-item>
 
-      <collapsible-item>
-        <div slot="title">Attributes</div>
-        <div slot="content">
+    <collapsible-item slot="item">
+      <div slot="title">Attributes</div>
+      <div slot="content">
         <div class="metadata-item">
           <div v-for="(item, index) in getAttributes" :key="index">
             <div v-for="(value, key) in item" :key="key">
@@ -37,26 +36,26 @@
               {{value}}
             </div>
           </div>
-        </div>      </div>
-      </collapsible-item>
-
-      <collapsible-item class="flex-grow-1">
-        <div slot="title">Text Snippets</div>
-        <div slot="content" class="knowledge-container">
-          <div v-for="(item, index) in getKnowledge" :key="index" class="snippet-container" @click="showMoreHandler(item.doi)">
-            <div class="snippet-title">
-              <a target="_blank" :href="item.URL">{{item.title}}</a>
-            </div>
-            <span v-for="(snippet, index) in item.highlight" :key="index" v-html="snippet" class="snippet-highlights"/>
-          </div>
         </div>
-      </collapsible-item>
-    </template>
+      </div>
+    </collapsible-item>
 
-    <div v-else class="alert alert-info" role="alert">
+    <collapsible-item slot="item" class="flex-grow-1">
+      <div slot="title">Text Snippets</div>
+      <div slot="content" class="h-100 position-absolute">
+        <div v-for="(item, index) in getKnowledge" :key="index" class="snippet-container" @click="showMoreHandler(item.doi)">
+          <div class="snippet-title">
+            <a target="_blank" :href="item.URL">{{item.title}}</a>
+          </div>
+          <span v-for="(snippet, index) in item.highlight" :key="index" v-html="snippet" class="snippet-highlights"/>
+        </div>
+      </div>
+    </collapsible-item>
+
+    <div slot="empty" class="alert alert-info" role="alert">
       No metadata at the moment
     </div>
-  </div>
+  </collapsible-container>
 </template>
 
 <script lang="ts">
@@ -66,10 +65,12 @@
   import Vue from 'vue';
   import { Prop } from 'vue-property-decorator';
 
-  import CollapsibleItem from '@/components/CollapsibleItem.vue';
+  import CollapsibleContainer from '@/components/Collapsible/CollapsibleContainer.vue';
+  import CollapsibleItem from '@/components/Collapsible/CollapsibleItem.vue';
   import { CosmosTextSnippet } from '@/types/typesCosmos';
 
   const components = {
+    CollapsibleContainer,
     CollapsibleItem,
   };
 
@@ -113,65 +114,31 @@
 <style lang="scss" scoped>
 @import "@/styles/variables";
 
-.metadata-pane-container {
-  display: flex;
-  flex-direction: column;
-  position: absolute;
+.metadata-item {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  hyphens: auto;
+  text-align: left;
+  margin-top: 5px;
+  padding: 5px;
+  .key {
+    font-weight: bold;
+    padding-top: 5px;
+  }
+}
+
+.snippet-container {
   height: 100%;
-  width: 100%;
-  overflow: hidden;
-  .metadata-container {
-    overflow:  hidden scroll;
-  }
-  .metadata-header {
-    padding: 5px;
-    color: $text-color-dark;
-    background-color: $drilldown-header;
-  }
-  .metadata-item {
-    overflow-wrap: break-word;
-    word-wrap: break-word;
-    hyphens: auto;
-    text-align: left;
-    margin-top: 5px;
-    padding: 5px;
-    .key {
+  overflow: auto;
+  border: 1px solid $border;
+  padding: 4px 8px;
+  box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
+  cursor: pointer;
+  .snippet-highlights {
+    font-size: 14px;
+    em {
       font-weight: bold;
-      padding-top: 5px;
     }
-  }
-
-  .knowledge-container {
-    height: 100%;
-    position: absolute;
-    .snippet-container {
-      height: 100%;
-      overflow: auto;
-      border: 1px solid $border;
-      padding: 4px 8px;
-      box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
-      cursor: pointer;
-      .snippet-highlights {
-        font-size: 14px;
-        em {
-          font-weight: bold;
-        }
-      }
-    }
-  }
-
-  .artifact-img {
-    width: 45%;
-    height: 0;
-    padding-top: 45%;
-    background-size: cover;
-    background-repeat: no-repeat;
-    background-position: center;
-    background-color: #EAEBEC;
-    float: left;
-    border: $icon-color solid 1px;
-    border-radius: 10px;
-    margin: 2.5%;
   }
 }
 </style>

--- a/client/src/views/Models/Epi/components/DrilldownPanel/ParametersPane.vue
+++ b/client/src/views/Models/Epi/components/DrilldownPanel/ParametersPane.vue
@@ -26,11 +26,9 @@
   import Vue from 'vue';
   import { Prop } from 'vue-property-decorator';
 
-  import CollapsibleItem from '@/components/CollapsibleItem.vue';
   import ScatterPlot from '@/components/widgets/charts/ScatterPlot.vue';
 
   const components = {
-    CollapsibleItem,
     ScatterPlot,
   };
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/14062458/111678223-7041d800-87f6-11eb-8bb0-f5be9a7879e2.mov

This applies to both the bio subgraph edges evidences and the epi metadata tab
