### PR TITLE
Load gzipped bgraph files

### DIFF
--- a/client/src/utils/BGraphUtil.ts
+++ b/client/src/utils/BGraphUtil.ts
@@ -1,5 +1,6 @@
 import s3Client from '@/services/S3Service';
 import { loadJSONLFile } from '@/utils/FileLoaderUtil';
+import { DataFile } from '@dekkai/data-source';
 
 // FIXME: Fix return type once bgraph library types are added
 export const loadBGraphData = async (): Promise<any[]> => {
@@ -7,13 +8,21 @@ export const loadBGraphData = async (): Promise<any[]> => {
     Bucket: process.env.S3_BUCKET,
     Key: process.env.S3_BGRAPH_EDGES_KEY,
   });
-  const bgEdges = await loadJSONLFile(getSignedBGraphEdgesUrl);
+  // TODO: @dekkai/data-source is unable to properly stream in gzipped files so we
+  // are using a workaround by fetching a blob until the following issue is fixed:
+  // https://github.com/dekkai-data/data-source/issues/1
+  const bgEdgesBlob = await (await fetch(getSignedBGraphEdgesUrl)).blob();
+  const bgEdges = await loadJSONLFile(await DataFile.fromLocalSource(bgEdgesBlob));
 
   const getSignedBGraphNodesUrl = s3Client.getSignedUrl('getObject', {
     Bucket: process.env.S3_BUCKET,
     Key: process.env.S3_BGRAPH_NODES_KEY,
   });
-  const bgNodes = await loadJSONLFile(getSignedBGraphNodesUrl);
+  // TODO: @dekkai/data-source is unable to properly stream in gzipped files so we
+  // are using a workaround by fetching a blob until the following issue is fixed:
+  // https://github.com/dekkai-data/data-source/issues/1
+  const bgNodesBlob = await (await fetch(getSignedBGraphNodesUrl)).blob();
+  const bgNodes = await loadJSONLFile(await DataFile.fromLocalSource(bgNodesBlob));
 
   return [bgNodes, bgEdges];
 };

--- a/client/src/utils/FileLoaderUtil.ts
+++ b/client/src/utils/FileLoaderUtil.ts
@@ -1,10 +1,8 @@
-import { DataFile } from '@dekkai/data-source';
+import { DataSource, DataFile } from '@dekkai/data-source';
 
 const SIZE_OF_2MB = 2 * 1024 * 1024;
 
-async function parseJSONL (input: string, cb: (obj: any) => void): Promise<void> {
-  const file = await DataFile.fromRemoteSource(input);
-
+async function parseJSONL (file: DataSource, cb: (obj: any) => void): Promise<void> {
   const chunkSizeInBytes = SIZE_OF_2MB;
   const byteLength = await file.byteLength;
   const decoder = new TextDecoder();
@@ -33,8 +31,12 @@ async function parseJSONL (input: string, cb: (obj: any) => void): Promise<void>
   }
 }
 
-export const loadJSONLFile = async (file: string, options: any = null): Promise<any[]> => {
+export const loadJSONLFile = async (file: DataSource | string, options: any = null): Promise<any[]> => {
   const parsedJSONL = [];
+
+  if (typeof (file) === 'string') {
+    file = await DataFile.fromRemoteSource(file);
+  }
 
   await parseJSONL(file, json => {
     parsedJSONL.push(Object.assign({}, json, options));


### PR DESCRIPTION
Allows loading gzipped bgraph files from remote server. Significantly reducing loading times and network data consumption from `~350MB` to `~30MB`.

Setup: Update your environment file (`.env`) to pull gzipped bgraph nodes and edges. See confluence
