### PR TITLE
feature/add sourcemaps to development build for debugging

### DIFF
--- a/client/esbuild.js
+++ b/client/esbuild.js
@@ -23,6 +23,8 @@ function getDistBuildOptions () {
     entryPoints: ['./build/js/main.js'],
     minify: true,
     bundle: true,
+    sourcemap: false,
+    target: 'es2020',
     outfile: './dist/js/main.js',
     define: Object.assign({
       'process.env.BASE_URL': '"/"',
@@ -36,6 +38,8 @@ function getDevBuildOptions () {
   return {
     entryPoints: ['./build/js/main.js'],
     bundle: true,
+    sourcemap: true,
+    target: 'es2020',
     outfile: './dev/js/main.js',
     define: Object.assign({
       'process.env.BASE_URL': '"/"',


### PR DESCRIPTION
Adding source maps to dev build. This allows us to debug in the browser's dev tools with the original source code. The below is what you see after this change in your dev tools source:

![Screen Shot 2021-03-29 at 10 29 31 AM](https://user-images.githubusercontent.com/15199528/112852239-bf4eff00-9079-11eb-99f1-c311a1c315e9.png)

And this is what you saw before the change:
![Screen Shot 2021-03-29 at 10 34 40 AM](https://user-images.githubusercontent.com/15199528/112853084-82cfd300-907a-11eb-9bc5-975244ad29e0.png)

