### PR TITLE
[BUGFIX] Fix vetur errors on Vue import paths

### DIFF
--- a/vetur.config.js
+++ b/vetur.config.js
@@ -1,0 +1,11 @@
+// Resolve `@/components/example` imports found in `lang='ts'` files relative to the ./client directory, rather than
+//  from the root directory.
+// This is helpful if you want to open the root directory in VS code
+//  without all .vue file imports throwing errors.
+// Read more here:
+// https://vuejs.github.io/vetur/guide/setup.html#advanced
+// https://vuejs.github.io/vetur/reference/
+/** @type {import('vls').VeturConfig} */
+module.exports = {
+  projects: ['./client']
+};


### PR DESCRIPTION
Vetur had trouble resolving import paths within Vue files as it declared root as the project's root not the clients.

Before: 
![Screen Shot 2021-04-06 at 4 23 12 PM](https://user-images.githubusercontent.com/15199528/113774242-02057c80-96f5-11eb-88ba-155068945806.png)

After: 
![Screen Shot 2021-04-06 at 4 22 51 PM](https://user-images.githubusercontent.com/15199528/113774263-092c8a80-96f5-11eb-8578-fd281a3a8a25.png)

Editor: VS Code