### PR TITLE
Integrate configurable cosmos img quality and fix no similar docs found error

### DIFF
--- a/client/src/components/SimilarDocs.vue
+++ b/client/src/components/SimilarDocs.vue
@@ -55,7 +55,7 @@
 
     async getSimilar (doi: string): Promise<void> {
       if (doi) {
-        const response = await cosmosSimilar({ doi });
+        const response = await cosmosSimilar({ doi, image_type: 'thumbnail' });
         response.data.map(similarDoc => {
           similarDoc.objects = similarDoc.objects.filter(object => object.bytes !== null).slice(0, ARTIFACT_LIMIT);
           return similarDoc;


### PR DESCRIPTION
These changes should decrease loading time of the drilldown modal while having miniscule effects on the observable image quality. I decided that for the preview image and thumbnail image, the cosmos thumbnails are too small and thus the observable quality difference is not acceptable. This also fixes an error I noticed where if the similar endpoint has no results an error appears in console.