### PR TITLE
Limit number query results

### DIFF
--- a/client/src/views/Models/Bio/Bio.vue
+++ b/client/src/views/Models/Bio/Bio.vue
@@ -199,8 +199,9 @@
           }
         }
     }
-    
+
     onGraferClick (detail: GraferEventDetail): void {
+      // eslint-disable-next-line
       console.log(`a [${detail.type}] with id [${detail.id}] on layer [${detail.layer}] was clicked!`);
     }
 


### PR DESCRIPTION
- This PR adds a condition for the local view where results are not displayed if they are larger than 500 elements (maybe we can move it up to 1000 but I want to see results with edges as well first). 
- Added simple alert messages to inform the user why results are not displayed and how she could get them visualized.


Video:
https://user-images.githubusercontent.com/10552785/114100461-4f6b2080-9892-11eb-8ceb-f256b15f91f3.mov

To test:
- Open a bio model from the Home page.
- Try to run some node queries and open the local view.
- Depending on the query, you should be able to see results or get a message informing on why they are not displayed.


