### PR TITLE
Fix massive img when only 1 related doc

### DIFF
--- a/client/src/components/SimilarDocs.vue
+++ b/client/src/components/SimilarDocs.vue
@@ -2,14 +2,14 @@
   <div>
     <h3 v-if="similarDocList.length > 0">Related documents</h3>
     <div class="row mr-0">
-      <div class="col" v-for="(similarDoc) in similarDocList" :key="similarDoc.bibjson._gddid">
+      <div class="col-3" v-for="(similarDoc) in similarDocList" :key="similarDoc.bibjson._gddid">
         <a :href="similarDoc.bibjson.link[0].url" target="_blank">
           <h6>{{similarDoc.bibjson.title}}</h6>
         </a>
       </div>
     </div>
     <div class="row mr-0">
-      <div class="d-flex col justify-content-between" v-for="(similarDoc) in similarDocList" :key="similarDoc.bibjson._gddid">
+      <div class="d-flex col-3 justify-content-between" v-for="(similarDoc) in similarDocList" :key="similarDoc.bibjson._gddid">
         <div v-for="(artifact) in similarDoc.objects" :key="artifact.id"
           class="similar-img shadow"
           :style="imageStyle(artifact.bytes)"


### PR DESCRIPTION
<img width="1077" alt="Screen Shot 2021-04-12 at 3 28 12 PM" src="https://user-images.githubusercontent.com/14062458/114450194-b5fa8200-9ba3-11eb-85ea-7378772f7c99.png">
