### PR TITLE
Made the left side panel push the content

### DIFF
--- a/client/src/components/LeftSidePanel.vue
+++ b/client/src/components/LeftSidePanel.vue
@@ -66,20 +66,21 @@
 @import "@/styles/variables";
 
 .left-side-panel-container {
-  width: 25vw;
-  height: $content-full-height;
-  box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
-  position: absolute;
-  display: flex;
-  flex-direction: column;
   background-color: #ffffff;
   box-sizing: border-box;
+  box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
+  display: flex;
+  flex-direction: column;
+  height: $content-full-height;
   padding: 5px;
+  position: relative; // for .navigation-control
+  width: 25vw;
+  will-change: width;
   z-index: map-get($z-index-order, side-panel);
 
   &.closed {
+    padding: 0px;
     width: 0px;
-    padding:0px;
 
     .tab-panel, .panel-content {
       display: none;
@@ -115,5 +116,4 @@
 .nav-link:not(.active) {
   cursor: pointer;
 }
-
 </style>

--- a/client/src/styles/custom.scss
+++ b/client/src/styles/custom.scss
@@ -1,12 +1,11 @@
 @import "variables";
 
 .view-container {
+  background-color: $bg-body;
   display: flex;
-  flex-direction: column;
-  position: relative;
   height: $content-full-height;
   overflow: hidden;
-  background-color: $bg-body;
+  position: relative;
 }
 
 .search-row {

--- a/client/src/views/GraphExperiment/GraphExperiment.vue
+++ b/client/src/views/GraphExperiment/GraphExperiment.vue
@@ -141,3 +141,9 @@
     }
   }
 </script>
+
+<style lang="scss" scoped>
+.view-container {
+  flex-direction: column;
+}
+</style>

--- a/client/src/views/Home/Home.vue
+++ b/client/src/views/Home/Home.vue
@@ -1,11 +1,14 @@
 <template>
   <div class="view-container">
-    <left-side-panel :tabs="tabs" :activeTabId="activeTabId">
+    <left-side-panel
+      class="left-side-panel"
+      :activeTabId="activeTabId"
+      :tabs="tabs"
+    >
       <div slot="content">
         <facets-pane />
       </div>
     </left-side-panel>
-
     <div class="d-flex flex-column h-100">
       <div class="search-row">
         <search-bar :pills="searchPills" :placeholder="`Search for models...`"/>
@@ -156,6 +159,10 @@
 
 <style lang="scss" scoped>
 @import "@/styles/variables";
+
+.left-side-panel {
+  flex-shrink: 0;
+}
 
 .view-button {
   padding: 2px 5px;

--- a/client/src/views/Knowledge/DocsCards/DocsCards.vue
+++ b/client/src/views/Knowledge/DocsCards/DocsCards.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="view-container flex-row">
+  <div class="view-container">
     <div class="d-flex flex-column h-100">
       <div class="search-row">
         <search-bar :pills="searchPills" :placeholder="`Search for documents including a specific keyword (e.g. IL-6)...`" />

--- a/client/src/views/Knowledge/DocsClusters/DocsClusters.vue
+++ b/client/src/views/Knowledge/DocsClusters/DocsClusters.vue
@@ -40,4 +40,7 @@
 </script>
 
 <style lang="scss" scoped>
+.view-container {
+  flex-direction: column;
+}
 </style>

--- a/client/src/views/Models/Bio/Bio.vue
+++ b/client/src/views/Models/Bio/Bio.vue
@@ -1,10 +1,15 @@
 <template>
-  <div class="view-container flex-row">
-    <left-side-panel :tabs="tabs" :activeTabId="activeTabId" @tab-click="onTabClick">
-          <div slot="content">
-            <metadata-panel v-if="activeTabId ===  'metadata'" :metadata="selectedModel && selectedModel.metadata"/>
-            <!-- <facets-pane v-if="activeTabId === 'facets'" /> -->
-          </div>
+  <div class="view-container">
+    <left-side-panel
+      class="left-side-panel"
+      :activeTabId="activeTabId"
+      :tabs="tabs"
+      @tab-click="onTabClick"
+    >
+      <div slot="content">
+        <metadata-panel v-if="activeTabId ===  'metadata'" :metadata="selectedModel && selectedModel.metadata"/>
+        <!-- <facets-pane v-if="activeTabId === 'facets'" /> -->
+      </div>
     </left-side-panel>
     <div class="d-flex flex-column flex-grow-1 position-relative">
       <div class="search-row">
@@ -273,5 +278,9 @@
 
   .grafer {
     flex-grow: 1;
+  }
+
+  .left-side-panel {
+    flex-shrink: 0;
   }
 </style>

--- a/client/src/views/Models/Comparison/Comparison.vue
+++ b/client/src/views/Models/Comparison/Comparison.vue
@@ -54,7 +54,6 @@
   import SettingsBar from '@/components/SettingsBar.vue';
   import Counters from '@/components/Counters.vue';
   import Settings from '@/views/Models/components/Settings.vue';
-  import LeftSidePanel from '@/components/LeftSidePanel.vue';
   import GlobalGraph from '@/views/Models/Epi/components/Graphs/GlobalGraph.vue';
   import IntersectionGraph from './components/Graphs/IntersectionGraph.vue';
   import ResizableGrid from '@/components/ResizableGrid/ResizableGrid.vue';
@@ -76,7 +75,6 @@
     SettingsBar,
     Counters,
     Settings,
-    LeftSidePanel,
     GlobalGraph,
     IntersectionGraph,
     ResizableGrid,
@@ -179,5 +177,7 @@
 </script>
 
 <style lang="scss" scoped>
-@import '@/styles/variables';
+.view-container {
+  flex-direction: column;
+}
 </style>

--- a/client/src/views/Models/Epi/Epi.vue
+++ b/client/src/views/Models/Epi/Epi.vue
@@ -1,10 +1,15 @@
 <template>
-  <div class="view-container flex-row">
-    <left-side-panel :tabs="tabs" :activeTabId="activeTabId" @tab-click="onTabClick">
-          <div slot="content">
-            <metadata-panel v-if="activeTabId ===  'metadata'" :metadata="selectedModel.metadata"/>
-            <facets-pane v-if="activeTabId === 'facets'" />
-          </div>
+  <div class="view-container">
+    <left-side-panel
+      class="left-side-panel"
+      :activeTabId="activeTabId"
+      :tabs="tabs"
+      @tab-click="onTabClick"
+    >
+      <div slot="content">
+        <metadata-panel v-if="activeTabId === 'metadata'" :metadata="selectedModel.metadata"/>
+        <facets-pane v-if="activeTabId === 'facets'" />
+      </div>
     </left-side-panel>
     <div class="d-flex flex-column flex-grow-1 position-relative">
       <div class="search-row">
@@ -519,4 +524,7 @@
 <style lang="scss" scoped>
   @import "@/styles/variables";
 
+  .left-side-panel {
+    flex-shrink: 0;
+  }
 </style>


### PR DESCRIPTION
**Why?**  
 - closes #175 

**How**
 - Remove the default `flex-direction: column` from the `.view-container` as this is now used only in few views.
 - Remove the `postion: absolute` from the _left side panel_.
 
**Testing**
 - Make sure that everywhere the left side panel is used, that it squeeze the content.

**Screenshot**
![test](https://user-images.githubusercontent.com/636801/115606450-b5ec3780-a2b1-11eb-9d12-2aacaaa1412b.gif)

**Anything else**
 - The responsive grid needs to update it's dimensions on resize. What do you think @mj3cheun? 
