### PR TITLE
[QUERY] Support case insensitive bio node name search

### DIFF
--- a/client/src/utils/BGraphUtil.ts
+++ b/client/src/utils/BGraphUtil.ts
@@ -76,11 +76,13 @@ const filterTermToPriorityRank = {
 export const executeBgraph = (bgraph: any, clause: Filter): any => {
   switch (clause.field) {
     case QUERY_FIELDS_MAP.BIO_NODE_NAME.field: {
-      const names = clause.values as string[];
+      let names = clause.values as string[];
+      // Filter matching case insensitive names
+      names = names.map(name => name.toLowerCase());
       return bgraph.filter(document => {
         if (document._type === 'node') {
           const node = document;
-          return names.some(name => name.toLowerCase() === node.name.toLowerCase());
+          return names.some(name => name === node.name.toLowerCase());
         }
         // Document is not a node
         return false;


### PR DESCRIPTION
Why
See #189

What
Small change, when a user makes a filter query for a node name we lower case both the nodes name and the users search.  

Testing
See screenshots

![Screen Shot 2021-04-23 at 12 03 15 PM](https://user-images.githubusercontent.com/15199528/115899006-3c2c8900-a42c-11eb-9736-e554a33194fc.png)
![Screen Shot 2021-04-23 at 12 03 30 PM](https://user-images.githubusercontent.com/15199528/115899007-3cc51f80-a42c-11eb-96e9-c1391c683258.png)

Closes #189 