### PR TITLE
Integrate Donu api

### DIFF
--- a/client/src/components/Cards/Card.vue
+++ b/client/src/components/Cards/Card.vue
@@ -41,7 +41,7 @@
     }
 
     get hasImage (): boolean {
-      return this.previewImageSrc !== '';
+      return this.previewImageSrc && this.previewImageSrc !== '';
     }
 
     get iconType (): string {

--- a/client/src/services/DonuService.ts
+++ b/client/src/services/DonuService.ts
@@ -4,14 +4,13 @@ import {
   DonuResponse,
   DonuRequest,
   DonuRequestCommand,
+  DonuType,
 } from '@/types/typesDonu';
 import { donuToModel } from '@/utils/DonuUtil';
 
-const { DONU_ENDPOINT } = process.env;
-
 /** Send the request to Donu */
 async function callDonu (request: DonuRequest): Promise<DonuResponse> {
-  const response = await fetch(DONU_ENDPOINT, {
+  const response = await fetch(process.env.DONU_ENDPOINT, {
     body: JSON.stringify(request),
     method: 'POST',
   });
@@ -19,21 +18,21 @@ async function callDonu (request: DonuRequest): Promise<DonuResponse> {
 }
 
 /** Fetch a complete list of available models from Donu API */
-export async function fetchModels (): Promise<ModelInterface[]> {
+export async function fetchDonuModels (): Promise<ModelInterface[]> {
   const request: DonuRequest = {
     command: DonuRequestCommand.LIST_MODELS,
   };
   const response = await callDonu(request);
   // TODO - transform DonuResponse into ModelInterface
-  return donuToModel(response?.models);
+  return donuToModel(response?.models) ?? null;
 }
 
 export async function getModelParameters (model: ModelInterface): Promise<DonuResponse> {
   const request: DonuRequest = {
     command: DonuRequestCommand.DESCRIBE_MODEL_INTERFACE,
     definition: {
-      source: { file: model.file },
-      type: model.type,
+      source: { file: model.metadata.source },
+      type: DonuType.EASEL,
     } as DonuModelDefinition,
   };
 

--- a/client/src/services/ModelsService.ts
+++ b/client/src/services/ModelsService.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { QUERY_FIELDS_MAP } from '@/utils/QueryFieldsUtil';
 import { MODEL_TYPE_OPTIONS } from '@/utils/ModelTypeUtil';
-import { ModelInterface } from '@/types/types';
+import { ModelInterface, ModelInterfaceType } from '@/types/types';
 
 const isModelFiltered = (model: ModelInterface, filters: any): boolean => {
   if (!filters) return false;
@@ -20,12 +20,12 @@ const isModelFiltered = (model: ModelInterface, filters: any): boolean => {
 
 /** Return a filtered list of Knowledge Graphs */
 const fetchGraphs = (models: ModelInterface[], filters: any[]): ModelInterface[] => {
-  return models.filter(model => model.type === 'biomechanism' && !isModelFiltered(model, filters));
+  return models.filter(model => model.type === ModelInterfaceType.biomechanism && !isModelFiltered(model, filters));
 };
 
 /** Return a filtered list of Computational Models */
 const fetchModels = (models: ModelInterface[], filters: any[]): ModelInterface[] => {
-  return models.filter(model => model.type === 'computational' && !isModelFiltered(model, filters));
+  return models.filter(model => model.type === ModelInterfaceType.computational && !isModelFiltered(model, filters));
 };
 
 const fetchModelTypesAgg = (models: ModelInterface[], filters: any[]): any => {

--- a/client/src/store/modules/models.ts
+++ b/client/src/store/modules/models.ts
@@ -1,10 +1,11 @@
 import _ from 'lodash';
 import { GetterTree, MutationTree, ActionTree } from 'vuex';
 
-import { ModelsState, ModelInterface } from '@/types/types';
+import { ModelsState, ModelInterface, ModelInterfaceType } from '@/types/types';
 
 import { emmaaModelList } from '@/services/EmmaaFetchService';
 import { getUtil } from '@/utils/FetchUtil';
+import { fetchDonuModels } from '@/services/DonuService';
 
 const state: ModelsState = {
   isInitialized: false,
@@ -101,7 +102,7 @@ const buildInitialModelsList = ({
         detailed: _.pick(nestedSIRGrFN, ['nodes', 'edges']),
       },
       subgraph: _.pick(comparisonJSON.subgraphs[0], ['nodes', 'edges']),
-      type: 'computational',
+      type: ModelInterfaceType.computational,
     },
     {
       id: 1,
@@ -111,7 +112,7 @@ const buildInitialModelsList = ({
         detailed: _.pick(nestedCHIMEGrFN, ['nodes', 'edges']),
       },
       subgraph: _.pick(comparisonJSON.subgraphs[1], ['nodes', 'edges']),
-      type: 'computational',
+      type: ModelInterfaceType.computational,
     },
     {
       id: 2,
@@ -120,7 +121,7 @@ const buildInitialModelsList = ({
         abstract: _.pick(nestedDoubleEpiCAG, ['nodes', 'edges']),
         detailed: _.pick(nestedDoubleEpiGrFN, ['nodes', 'edges']),
       },
-      type: 'computational',
+      type: ModelInterfaceType.computational,
     },
   ];
 };
@@ -214,6 +215,10 @@ const actions: ActionTree<ModelsState, any> = {
     });
     commit('setComparisonHighlights', initialComparisonHighlights);
 
+    // Add DONU models
+    const donuModels = await fetchDonuModels();
+    donuModels.forEach(model => commit('addModel', model));
+
     commit('setIsInitialized', true);
   },
 };
@@ -226,11 +231,11 @@ const getters: GetterTree<ModelsState, any> = {
   getComparisonHighlights: state => state.comparisonHighlights,
 
   getCountComputationalModels: function (state: ModelsState): number {
-    return state.modelsList.filter(model => model.type === 'computational').length;
+    return state.modelsList.filter(model => model.type === ModelInterfaceType.computational).length;
   },
 
   getCountGraphsModels: function (state: ModelsState): number {
-    return state.modelsList.filter(model => model.type === 'biomechanism').length;
+    return state.modelsList.filter(model => model.type === ModelInterfaceType.biomechanism).length;
   },
 
   getSelectedGraph: state => state.selectedGraph,

--- a/client/src/types/types.ts
+++ b/client/src/types/types.ts
@@ -16,12 +16,17 @@ interface ModelComponentMetadataInterface {
   knowledge: string
 }
 
+export enum ModelInterfaceType {
+  computational = 'computational',
+  biomechanism = 'biomechanism',
+}
+
 interface ModelInterface {
-  id: number;
+  id?: number;
   metadata: ModelMetadataInterface,
-  graph: any,
+  graph?: any,
   subgraph?: any,
-  type: 'computational' | 'biomechanism'
+  type: ModelInterfaceType
 }
 
 interface TabInterface {

--- a/client/src/types/typesDonu.ts
+++ b/client/src/types/typesDonu.ts
@@ -12,7 +12,7 @@ export enum DonuRequestCommand {
   // UPLOAD_MODEL = 'upload-model',
 }
 
-enum DonuType {
+export enum DonuType {
   EASEL = 'easel',
   // DIFF_EQ = 'diff-eq',
   // GROMET = 'gromet',

--- a/client/src/utils/DonuUtil.ts
+++ b/client/src/utils/DonuUtil.ts
@@ -1,8 +1,17 @@
 /** Utilities to manipulate Donu Types */
-import { ModelInterface } from '@/types/types';
+import { ModelInterface, ModelInterfaceType } from '@/types/types';
 import { DonuModelDefinition } from '@/types/typesDonu';
 
 /** Transform a Donu Model to a ModelInterface */
-export function donuToModel (models: DonuModelDefinition[]): ModelInterface[] {
-  return models as unknown as ModelInterface[];
+export function donuToModel (donuModels: DonuModelDefinition[]): ModelInterface[] {
+  return donuModels.map((model, index) => {
+    return {
+      metadata: {
+        name: model.name ?? 'Donu ' + index,
+        source: model.source.file,
+      },
+      graph: null,
+      type: ModelInterfaceType.computational,
+    } as ModelInterface;
+  });
 }


### PR DESCRIPTION
**What**
- Integrate Donu API into the HMI, close #212 

**How**
- Created a new _Service_ to call Donu API and fetch Models
- Created a new _Types_ to describe the [Donu API](https://galoisinc.github.io/ASKE-E/donu.html)
- Created a new _Utils_ to transform Donu response into HMI types
- Call the Donu API model list at the same time we add the model by hand in the VueX store.

**Screenshot**

![Screen Shot 2021-05-31 at 14 32 59](https://user-images.githubusercontent.com/636801/120230333-1a89a300-c21d-11eb-87ea-adba8ef55772.png)

**Testing**
- Check that the _Models_ page show the Donu Models
- Make sure that no XHR issue or HMI problems arise

**Questions**
- We need more information from the Donu API to match out UX
