### PR TITLE
Sort parameter values and variables in ascending order 

### DIFF
--- a/client/src/views/Simulation/Simulation.vue
+++ b/client/src/views/Simulation/Simulation.vue
@@ -90,7 +90,6 @@
 
   import VariablesPanel from './components/VariablesPanel.vue';
 
-
   /**
   Temporary hack for workshop
   **/
@@ -138,6 +137,7 @@
       }
       return this.getModelsList.find(model => model.id === Number(this.getSelectedModelIds[0]));
     }
+
     get gridMap (): string[][] {
       return this.expandedId
       ? [[this.expandedId]]

--- a/client/src/views/Simulation/Simulation.vue
+++ b/client/src/views/Simulation/Simulation.vue
@@ -48,7 +48,7 @@
               <i class="fas fa-expand-alt"/>
             </button>
           </settings-bar>
-          <global-graph v-if="selectedModel" :data="selectedGraph"/>
+          <!-- <global-graph v-if="selectedModel" :data="selectedGraph"/> -->
         </div>
         <parameters-panel
           slot="parameters" class="h-100 w-100 d-flex flex-column"
@@ -56,7 +56,7 @@
           @expand="setExpandedId('parameters')"
           @settings="onCloseSimView"
         />
-        <variable-panel
+        <variables-panel
           :model="selectedModel"
           slot="variables"
           @expand="setExpandedId('variables')"
@@ -73,7 +73,7 @@
   import { Action, Getter, Mutation } from 'vuex-class';
   import { RawLocation } from 'vue-router';
 
-  import { SimulationParameter, TabInterface, ViewInterface, ModelInterface } from '@/types/types';
+  import { SimulationParameter, ModelInterface } from '@/types/types';
   import { GraphInterface } from '@/types/typesGraphs';
   import { DimensionsInterface } from '@/types/typesResizableGrid';
 
@@ -88,17 +88,8 @@
   import SearchBar from '@/components/SearchBar.vue';
   import ParametersPanel from '@/views/Simulation/components/ParametersPanel.vue';
 
-  import VariablePanel from './components/VariablePanel.vue';
+  import VariablesPanel from './components/VariablesPanel.vue';
 
-  const TABS: TabInterface[] = [
-    { name: 'Facets', icon: 'filter', id: 'facets' },
-    { name: 'Metadata', icon: 'info', id: 'metadata' },
-  ];
-
-  const VIEWS: ViewInterface[] = [
-    { name: 'Causal', id: 'causal' },
-    { name: 'Functional', id: 'functional' },
-  ];
 
   /**
   Temporary hack for workshop
@@ -113,17 +104,11 @@
     Settings,
     SettingsBar,
     ParametersPanel,
-    VariablePanel,
+    VariablesPanel,
   };
 
   @Component({ components })
-  export default class Model extends Vue {
-    views: ViewInterface[] = VIEWS;
-    selectedViewId = 'causal';
-
-    tabs: TabInterface[] = TABS;
-    activeTabId: string = 'metadata';
-
+  export default class Simulation extends Vue {
     subgraph: GraphInterface = null;
     parameters: SimulationParameter[] = [];
 
@@ -153,11 +138,6 @@
       }
       return this.getModelsList.find(model => model.id === Number(this.getSelectedModelIds[0]));
     }
-
-    get selectedGraph (): GraphInterface {
-      return this.selectedViewId === 'causal' ? this.selectedModel?.graph?.abstract : this.selectedModel?.graph?.detailed;
-    }
-
     get gridMap (): string[][] {
       return this.expandedId
       ? [[this.expandedId]]

--- a/client/src/views/Simulation/components/ParametersPanel.vue
+++ b/client/src/views/Simulation/components/ParametersPanel.vue
@@ -77,6 +77,7 @@
 </template>
 
 <script lang="ts">
+  import _ from 'lodash';
   import Vue from 'vue';
   import Component from 'vue-class-component';
   import { Action, Getter } from 'vuex-class';
@@ -92,7 +93,7 @@
   };
 
   @Component({ components })
-  export default class SimulationParameters extends Vue {
+  export default class ParametersPanel extends Vue {
     @Prop({ default: false }) expanded: boolean;
     @InjectReactive() resized!: boolean; // eslint-disable-line new-cap
     @InjectReactive() isResizing!: boolean; // eslint-disable-line new-cap
@@ -112,7 +113,8 @@
     @Watch('isResizing') onIsResising (): void { this.isResizing && this.clearGraph(); }
 
     get parameters (): HMI.SimulationParameter[] {
-      return this.getSimParameters;
+      // Order by ASC order
+      return _.orderBy(this.getSimParameters, ['name'], ['asc']);
     }
 
     get countersTitle (): string {

--- a/client/src/views/Simulation/components/VariablesPanel.vue
+++ b/client/src/views/Simulation/components/VariablesPanel.vue
@@ -56,8 +56,7 @@
   import { getModelResult } from '@/services/DonuService';
   import { donuSimulateToD3 } from '@/utils/DonuUtil';
 
-import * as HMI from '@/types/types';
-import { AnyRecordWithTtl } from 'dns';
+  import * as HMI from '@/types/types';
 
   const components = {
     SettingsBar,


### PR DESCRIPTION
**What**
- Sorted parameter values in ascending order
- Sorted variables panel in ascending order
- I also cleaned up some unused code in the `Simulation` view that has been carried over from copying and pasting.
- BONUS: I also added the counter values for the variables panel. 

**How**
- Used the `orderBy` lodash function.
- For the variables counters, I mostly emulated how we do it for the parameters counter.

**Screenshot**
![image](https://user-images.githubusercontent.com/10552785/122087707-03c57d80-cdd3-11eb-9006-aa0c9045213a.png)

**Notes**
In the future, we might want to add support for the user to select the order criteria (descending, ascending, etc.)

**Testing**
- Select a model.
- Click on `Open Simulation View`
- Parameters and variables should be ordered in ascending order.