### PR TITLE
[FEATURE ] Add bio path query

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.30",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/vue-fontawesome": "^2.0.0",
-    "@uncharted.software/bgraph": "0.1.0",
+    "@uncharted.software/bgraph": "0.2.0",
     "@uncharted.software/facets-core": "^3.1.0",
     "@uncharted.software/facets-plugins": "^3.1.0",
     "@uncharted.software/grafer": "0.3.0",

--- a/client/src/utils/BGraphQueryUtil.ts
+++ b/client/src/utils/BGraphQueryUtil.ts
@@ -34,6 +34,7 @@ export function bioPathPost (bgraphPathQuery, clause: Filter): any {
     return false;
   })
     .repeat(5) // TODO: Implement cycle detection in bgraph to remove bio path length limit
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     .filter(_ => false)
     .unsuspend();
 }

--- a/client/src/utils/BGraphQueryUtil.ts
+++ b/client/src/utils/BGraphQueryUtil.ts
@@ -1,0 +1,149 @@
+import { Filter } from '@/types/typesLex';
+import { BIO_EDGE_TYPE_OPTIONS } from '@/utils/ModelTypeUtil';
+
+// PATH QUERIES
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function bioPathPre (bgraphPathQuery: any, clause: Filter): any {
+  return bgraphPathQuery.filter(document => {
+    if (document._type === 'node') {
+      const node = document;
+      return node.group_map[clause.values[0]] !== undefined;
+    }
+    // Document type is an edge
+    return false;
+  })
+    .start()
+    .unique();
+}
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types
+export function bioPathPreNodeFilterLoop (bgraphPathQuery, _clause: Filter): any {
+  return bgraphPathQuery.out();
+}
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types
+export function bioPathPreEdgeFilterLoop (bgraphPathQuery, _clause: Filter): any {
+  return bgraphPathQuery.out();
+}
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function bioPathPost (bgraphPathQuery, clause: Filter): any {
+  return bgraphPathQuery.suspend(document => {
+    if (document._type === 'node') {
+      const node = document;
+      return node.group_map[clause.values[1]] !== undefined;
+    }
+    // Document type is an edge
+    return false;
+  })
+    .repeat(5) // TODO: Implement cycle detection in bgraph to remove bio path length limit
+    .filter(_ => false)
+    .unsuspend();
+}
+
+// EDGE QUERIES
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function bioEdgeTested (bgraphPathQuery, clause: Filter): any {
+  return bgraphPathQuery.filter(document => {
+    if (document._type === 'edge') {
+      const edge = document;
+      return edge.tested === Boolean(clause.values[0]);
+    }
+    // Document is not an edge
+    return false;
+  });
+}
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function bioEdgeType (bgraphPathQuery, clause: Filter): any {
+  return bgraphPathQuery.filter(document => {
+    if (document._type === 'edge') {
+      const edge = document;
+      return clause.values.some(typeIdx => BIO_EDGE_TYPE_OPTIONS[typeIdx] === edge.statement_type);
+    }
+    // Document is not an edge
+    return false;
+  });
+}
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function bioEdgeDOI (bgraphPathQuery, clause: Filter): any {
+  let dois = clause.values as string[];
+  dois = dois.map(doi => doi.toLowerCase());
+  return bgraphPathQuery.filter(document => {
+    if (document._type === 'edge') {
+      const edge = document;
+      return dois.some(doi => Object.keys(edge.doi_map).some(edgeDoi => {
+        return edgeDoi.toLowerCase().includes(doi);
+      }));
+    }
+    // Document is not an edge
+    return false;
+  });
+}
+
+// NODE QUERIES
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function bioNodeName (bgraphPathQuery, clause: Filter): any {
+  let names = clause.values as string[];
+  // Filter matching case insensitive names
+  names = names.map(name => name.toLowerCase());
+  return bgraphPathQuery.filter(document => {
+    if (document._type === 'node') {
+      const node = document;
+      return names.some(name => name === node.name.toLowerCase());
+    }
+    // Document is not a node
+    return false;
+  });
+}
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function bioNodeGroup (bgraphPathQuery, clause: Filter): any {
+  return bgraphPathQuery.filter(document => {
+    if (document._type === 'node') {
+      const node = document;
+      return clause.values.some(group => node.group_map[group] !== undefined);
+    }
+    // Document type is an edge
+    return false;
+  });
+}
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function bioNodeGrounded (bgraphPathQuery, clause: Filter): any {
+  return bgraphPathQuery.filter(document => {
+    if (document._type === 'node') {
+      const node = document;
+      return node.grounded_db === Boolean(clause.values[0]);
+    }
+    // Document type is an edge
+    return false;
+  });
+}
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function bioNodeGroundedOnto (bgraphPathQuery, clause: Filter): any {
+  return bgraphPathQuery.filter(document => {
+    if (document._type === 'node') {
+      const node = document;
+      return node.grounded_group === Boolean(clause.values[0]);
+    }
+    // Document type is an edge
+    return false;
+  });
+}
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function bioNodeInDegree (bgraphPathQuery, clause: Filter): any {
+  return bgraphPathQuery.filter(document => {
+    if (document._type === 'node') {
+      const node = document;
+      return clause.values.some(value => node.in_degree === Number(value));
+    }
+    // Document type is an edge
+    return false;
+  });
+}
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function bioNodeOutDegree (bgraphPathQuery, clause: Filter): any {
+  return bgraphPathQuery.filter(document => {
+    if (document._type === 'node') {
+      const node = document;
+      return clause.values.some(value => node.out_degree === Number(value));
+    }
+    // Document type is an edge
+    return false;
+  });
+}

--- a/client/src/utils/BGraphUtil.ts
+++ b/client/src/utils/BGraphUtil.ts
@@ -54,24 +54,31 @@ export const loadBGraphData = (nodesPath: string, edgesPath: string): Promise<an
 };
 
 // Add filter terms here to change the order in which they are processed in bgraph
-const NODE_PRIORITY_RANK = 1;
-const EDGE_PRIORITY_RANK = 4;
+const EDGE_PRIORITY_RANK = 2;
+const NODE_PRIORITY_RANK = 4;
+const PATH_PRIORITY_RANK = 7;
 const filterTermToPriorityRank = {
+  // Edge Terms
+  [QUERY_FIELDS_MAP.BIO_EDGE_PRE.field]: 1,
+  [QUERY_FIELDS_MAP.BIO_EDGE_TESTED.field]: EDGE_PRIORITY_RANK,
+  [QUERY_FIELDS_MAP.BIO_EDGE_TYPE.field]: EDGE_PRIORITY_RANK,
+  [QUERY_FIELDS_MAP.BIO_EDGE_DOI.field]: EDGE_PRIORITY_RANK,
+  [QUERY_FIELDS_MAP.BIO_EDGE_POST.field]: 3,
   // Node Terms
-  [QUERY_FIELDS_MAP.BIO_NODE_PRE.field]: 0,
+  [QUERY_FIELDS_MAP.BIO_NODE_PRE.field]: 4,
   [QUERY_FIELDS_MAP.BIO_NODE_NAME.field]: NODE_PRIORITY_RANK,
   [QUERY_FIELDS_MAP.BIO_NODE_GROUP.field]: NODE_PRIORITY_RANK,
   [QUERY_FIELDS_MAP.BIO_NODE_GROUNDED.field]: NODE_PRIORITY_RANK,
   [QUERY_FIELDS_MAP.BIO_NODE_GROUNDED_ONTO.field]: NODE_PRIORITY_RANK,
   [QUERY_FIELDS_MAP.BIO_NODE_IN_DEGREE.field]: NODE_PRIORITY_RANK,
   [QUERY_FIELDS_MAP.BIO_NODE_OUT_DEGREE.field]: NODE_PRIORITY_RANK,
-  [QUERY_FIELDS_MAP.BIO_NODE_POST.field]: 2,
-  // Edge Terms
-  [QUERY_FIELDS_MAP.BIO_EDGE_PRE.field]: 3,
-  [QUERY_FIELDS_MAP.BIO_EDGE_TESTED.field]: EDGE_PRIORITY_RANK,
-  [QUERY_FIELDS_MAP.BIO_EDGE_TYPE.field]: EDGE_PRIORITY_RANK,
-  [QUERY_FIELDS_MAP.BIO_EDGE_DOI.field]: EDGE_PRIORITY_RANK,
-  [QUERY_FIELDS_MAP.BIO_EDGE_POST.field]: 5,
+  [QUERY_FIELDS_MAP.BIO_NODE_POST.field]: 6,
+  // Path Terms
+  [QUERY_FIELDS_MAP.BIO_PATH_PRE.field]: 0,
+  [QUERY_FIELDS_MAP.BIO_PATH_PRE_EDGE_FILTER_LOOP.field]: 1,
+  [QUERY_FIELDS_MAP.BIO_PATH_PRE_NODE_FILTER_LOOP.field]: 3,
+  [QUERY_FIELDS_MAP.BIO_PATH.field]: PATH_PRIORITY_RANK,
+  [QUERY_FIELDS_MAP.BIO_PATH_POST.field]: 8,
 };
 
 // Assume that bgraph instance passed in has already been initialized
@@ -121,6 +128,145 @@ export const executeBgraphEdges = (bgraphEdgeQuery: any, clause: Filter): any =>
     }
     default: {
       return bgraphEdgeQuery;
+    }
+  }
+};
+
+// Assume that bgraph instance passed in has already been initialized
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const executeBgraphPathQuery = (bgraphPathQuery: any, clause: Filter): any => {
+  switch (clause.field) {
+    // EDGE CLAUSES
+    case QUERY_FIELDS_MAP.BIO_PATH_PRE.field: {
+      return bgraphPathQuery.filter(document => {
+        if (document._type === 'node') {
+          const node = document;
+          return node.group_map[clause.values[0]] !== undefined;
+        }
+        // Document type is an edge
+        return false;
+      })
+        .start()
+        .unique();
+    }
+    case QUERY_FIELDS_MAP.BIO_PATH_PRE_NODE_FILTER_LOOP.field: {
+      return bgraphPathQuery.out();
+    }
+    case QUERY_FIELDS_MAP.BIO_PATH_PRE_EDGE_FILTER_LOOP.field: {
+      return bgraphPathQuery.out();
+    }
+    case QUERY_FIELDS_MAP.BIO_PATH_POST.field: {
+      return bgraphPathQuery.suspend(document => {
+        if (document._type === 'node') {
+          const node = document;
+          return node.group_map[clause.values[1]] !== undefined;
+        }
+        // Document type is an edge
+        return false;
+      })
+        .repeat(5)
+        .filter(_ => false)
+        .unsuspend();
+    }
+    case QUERY_FIELDS_MAP.BIO_EDGE_TESTED.field: {
+      return bgraphPathQuery.filter(document => {
+        if (document._type === 'edge') {
+          const edge = document;
+          return edge.tested === Boolean(clause.values[0]);
+        }
+        // Document is not an edge
+        return false;
+      });
+    }
+    case QUERY_FIELDS_MAP.BIO_EDGE_TYPE.field: {
+      return bgraphPathQuery.filter(document => {
+        if (document._type === 'edge') {
+          const edge = document;
+          return clause.values.some(typeIdx => BIO_EDGE_TYPE_OPTIONS[typeIdx] === edge.statement_type);
+        }
+        // Document is not an edge
+        return false;
+      });
+    }
+    case QUERY_FIELDS_MAP.BIO_EDGE_DOI.field: {
+      let dois = clause.values as string[];
+      dois = dois.map(doi => doi.toLowerCase());
+      return bgraphPathQuery.filter(document => {
+        if (document._type === 'edge') {
+          const edge = document;
+          return dois.some(doi => Object.keys(edge.doi_map).some(edgeDoi => {
+            return edgeDoi.toLowerCase().includes(doi);
+          }));
+        }
+        // Document is not an edge
+        return false;
+      });
+    }
+    case QUERY_FIELDS_MAP.BIO_NODE_NAME.field: {
+      let names = clause.values as string[];
+      // Filter matching case insensitive names
+      names = names.map(name => name.toLowerCase());
+      return bgraphPathQuery.filter(document => {
+        if (document._type === 'node') {
+          const node = document;
+          return names.some(name => name === node.name.toLowerCase());
+        }
+        // Document is not a node
+        return false;
+      });
+    }
+    case QUERY_FIELDS_MAP.BIO_NODE_GROUP.field: {
+      return bgraphPathQuery.filter(document => {
+        if (document._type === 'node') {
+          const node = document;
+          return clause.values.some(group => node.group_map[group] !== undefined);
+        }
+        // Document type is an edge
+        return false;
+      });
+    }
+    case QUERY_FIELDS_MAP.BIO_NODE_GROUNDED.field: {
+      return bgraphPathQuery.filter(document => {
+        if (document._type === 'node') {
+          const node = document;
+          return node.grounded_db === Boolean(clause.values[0]);
+        }
+        // Document type is an edge
+        return false;
+      });
+    }
+    case QUERY_FIELDS_MAP.BIO_NODE_GROUNDED_ONTO.field: {
+      return bgraphPathQuery.filter(document => {
+        if (document._type === 'node') {
+          const node = document;
+          return node.grounded_group === Boolean(clause.values[0]);
+        }
+        // Document type is an edge
+        return false;
+      });
+    }
+    case QUERY_FIELDS_MAP.BIO_NODE_IN_DEGREE.field: {
+      return bgraphPathQuery.filter(document => {
+        if (document._type === 'node') {
+          const node = document;
+          return clause.values.some(value => node.in_degree === Number(value));
+        }
+        // Document type is an edge
+        return false;
+      });
+    }
+    case QUERY_FIELDS_MAP.BIO_NODE_OUT_DEGREE.field: {
+      return bgraphPathQuery.filter(document => {
+        if (document._type === 'node') {
+          const node = document;
+          return clause.values.some(value => node.out_degree === Number(value));
+        }
+        // Document type is an edge
+        return false;
+      });
+    }
+    default: {
+      return bgraphPathQuery;
     }
   }
 };
@@ -220,26 +366,71 @@ export const filterToBgraph = (bgraph: any, filters: Filters): any => {
       clauses.push(QUERY_FIELDS_MAP.BIO_EDGE_POST as unknown as Filter);
     }
 
+    let hasPathFilters = false;
+    for (const clause of clauses) {
+      if (filterTermToPriorityRank[clause.field] === PATH_PRIORITY_RANK) {
+        hasPathFilters = true;
+        // Set value on PRE- path query clause
+        const prePathClause = QUERY_FIELDS_MAP.BIO_PATH_PRE as unknown as Filter;
+        prePathClause.values = clause.values[0]; // Set "from" value
+        clauses.push(prePathClause);
+        // Set value on -POST path query clause
+        const postPathClause = QUERY_FIELDS_MAP.BIO_PATH_POST as unknown as Filter;
+        postPathClause.values = clause.values[0]; // Set "to" value
+        clauses.push(postPathClause);
+        clauses.push(QUERY_FIELDS_MAP.BIO_PATH_PRE_EDGE_FILTER_LOOP as unknown as Filter);
+        clauses.push(QUERY_FIELDS_MAP.BIO_PATH_PRE_NODE_FILTER_LOOP as unknown as Filter);
+      }
+    }
+
     const sortedClauses = clauses.sort((clause1, clause2) =>
       filterTermToPriorityRank[clause1.field] - filterTermToPriorityRank[clause2.field]);
 
     let bgraphEdgeQuery = bgraph.v();
     let bgraphNodeQuery = bgraph.v();
-    if (hasNodeFilters) {
+    let bgraphPathQuery = bgraph.v();
+    if (hasPathFilters) {
       sortedClauses.map(clause => {
-        bgraphNodeQuery = executeBgraphNodes(bgraphNodeQuery, clause);
+        bgraphPathQuery = executeBgraphPathQuery(bgraphEdgeQuery, clause);
       });
-    }
-    if (hasEdgeFilters) {
-      sortedClauses.map(clause => {
-        bgraphEdgeQuery = executeBgraphEdges(bgraphEdgeQuery, clause);
-      });
-    }
 
-    const bgraphNodeQueryResults = hasNodeFilters ? bgraphNodeQuery.unique().run() : [];
-    const bgraphEdgeQueryResults = hasEdgeFilters ? bgraphEdgeQuery.unique().run() : [];
-    const bgraphQueryResults = _.uniqBy(bgraphNodeQueryResults.concat(bgraphEdgeQueryResults), '_id');
-    return deepCopy(bgraphQueryResults, ['_in', '_out']);
+      const bgraphPathQueryResults = bgraphPathQuery
+        .unique()
+        .run();
+      const flattenedBGraphPathQueryResults = [];
+      for (let i = 0; i < bgraphPathQueryResults.length; i++) {
+        const result = bgraphPathQueryResults[i].result || bgraphPathQueryResults[i].vertex;
+        flattenedBGraphPathQueryResults.push(result);
+
+        // Append path query results
+        // TODO: Consider adding a way to flatten paths as a bgraph pipeline step
+        const path = bgraphPathQueryResults[i].state?.path || [];
+        for (const vertex of path) {
+          flattenedBGraphPathQueryResults.push(vertex);
+        }
+      }
+      const bgraphQueryResults = _.uniqBy(flattenedBGraphPathQueryResults, '_id');
+      return deepCopy(bgraphQueryResults, ['_in', '_out']);
+    } else {
+      if (hasNodeFilters) {
+        sortedClauses.map(clause => {
+          bgraphNodeQuery = executeBgraphNodes(bgraphNodeQuery, clause);
+        });
+      }
+      if (hasEdgeFilters) {
+        sortedClauses.map(clause => {
+          bgraphEdgeQuery = executeBgraphEdges(bgraphEdgeQuery, clause);
+        });
+      }
+
+      let bgraphNodeQueryResults = hasNodeFilters ? bgraphNodeQuery.unique().run() : [];
+      let bgraphEdgeQueryResults = hasEdgeFilters ? bgraphEdgeQuery.unique().run() : [];
+      bgraphNodeQueryResults = bgraphNodeQueryResults.map(gremlin => gremlin.result || gremlin.vertex);
+      bgraphEdgeQueryResults = bgraphEdgeQueryResults.map(gremlin => gremlin.result || gremlin.vertex);
+
+      const bgraphQueryResults = _.uniqBy(bgraphNodeQueryResults.concat(bgraphEdgeQueryResults), '_id');
+      return deepCopy(bgraphQueryResults, ['_in', '_out']);
+    }
   }
 };
 

--- a/client/src/utils/BGraphUtil.ts
+++ b/client/src/utils/BGraphUtil.ts
@@ -121,9 +121,6 @@ export const executeBgraphPathQuery = (bgraphPathQuery: any, clause: Filter): an
     case QUERY_FIELDS_MAP.BIO_PATH_PRE_EDGE_FILTER_LOOP.field: {
       return BGraphQueryUtil.bioPathPreEdgeFilterLoop(bgraphPathQuery, clause);
     }
-    case QUERY_FIELDS_MAP.BIO_PATH_POST.field: {
-      return BGraphQueryUtil.bioPathPost(bgraphPathQuery, clause);
-    }
     case QUERY_FIELDS_MAP.BIO_EDGE_TESTED.field: {
       return BGraphQueryUtil.bioEdgeTested(bgraphPathQuery, clause);
     }
@@ -150,6 +147,9 @@ export const executeBgraphPathQuery = (bgraphPathQuery: any, clause: Filter): an
     }
     case QUERY_FIELDS_MAP.BIO_NODE_OUT_DEGREE.field: {
       return BGraphQueryUtil.bioNodeOutDegree(bgraphPathQuery, clause);
+    }
+    case QUERY_FIELDS_MAP.BIO_PATH_POST.field: {
+      return BGraphQueryUtil.bioPathPost(bgraphPathQuery, clause);
     }
     default: {
       return bgraphPathQuery;
@@ -209,7 +209,7 @@ export const filterToBgraph = (bgraph: any, filters: Filters): any => {
 
     let hasPathFilters = false;
     for (const clause of clauses) {
-      if (filterTermToPriorityRank[clause.field] === PATH_PRIORITY_RANK) {
+      if (clause.field === QUERY_FIELDS_MAP.BIO_PATH.field) {
         hasPathFilters = true;
         // Set value on PRE- path query clause
         const prePathClause = QUERY_FIELDS_MAP.BIO_PATH_PRE as unknown as Filter;

--- a/client/src/utils/QueryFieldsUtil.ts
+++ b/client/src/utils/QueryFieldsUtil.ts
@@ -126,6 +126,36 @@ const QUERY_FIELDS_MAP: QueryFieldMap = {
     baseType: 'integer',
     lexType: 'integer',
   },
+  BIO_PATH_PRE: {
+    ..._field('bioPathPre', 'Path Pre'),
+    ..._searchable('Path Pre', false),
+    baseType: 'integer',
+    lexType: 'integer',
+  },
+  BIO_PATH_PRE_EDGE_FILTER_LOOP: {
+    ..._field('bioPathPreEdgeFilters', 'Path Pre Edge Filters'),
+    ..._searchable('Path Pre', false),
+    baseType: 'integer',
+    lexType: 'integer',
+  },
+  BIO_PATH_PRE_NODE_FILTER_LOOP: {
+    ..._field('bioPathPreNodeFilters', 'Path Pre Node Filters'),
+    ..._searchable('Path Pre', false),
+    baseType: 'integer',
+    lexType: 'integer',
+  },
+  BIO_PATH: {
+    ..._field('pathQuery', 'Path Query'),
+    ..._searchable('Path Query', false),
+    baseType: 'string',
+    lexType: 'string',
+  },
+  BIO_PATH_POST: {
+    ..._field('bioPathPost', 'Path Post'),
+    ..._searchable('Path Post', false),
+    baseType: 'integer',
+    lexType: 'integer',
+  },
   // COSMOS
   COSMOS_QUERY: {
     ..._field('cosmosQuery', 'Keyword'),

--- a/client/src/views/Graphs/components/SearchBar.vue
+++ b/client/src/views/Graphs/components/SearchBar.vue
@@ -14,6 +14,7 @@
   import { Lex } from '@uncharted.software/lex/dist/lex';
   import TextPill from '@/search/pills/TextPill';
   import KeyValuePill from '@/search/pills/KeyValuePill';
+  import PathQueryPill from '@/search/pills/PathQueryPill';
 
   import * as filtersUtil from '@/utils/FiltersUtil';
   import { QUERY_FIELDS_MAP } from '@/utils/QueryFieldsUtil';
@@ -64,6 +65,7 @@
           '',
           { single: true, multiValue: true },
         ),
+        new PathQueryPill(QUERY_FIELDS_MAP.BIO_PATH),
       ];
 
       this.lex = initializeLex({

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,10 +561,10 @@
     "@typescript-eslint/types" "4.4.0"
     eslint-visitor-keys "^2.0.0"
 
-"@uncharted.software/bgraph@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@uncharted.software/bgraph/-/bgraph-0.1.0.tgz#6ecc71ace9b3a5373002aaaf164e4d4a70f63c08"
-  integrity sha512-BHpnjpYETFybvqYrnv0yxIAlhtVPBO0du3/Mj+uRaRmVmANUQH0GW0QNTgWnbZdE5GmLCT5MRKFs3iZkl7lvWg==
+"@uncharted.software/bgraph@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@uncharted.software/bgraph/-/bgraph-0.2.0.tgz#45b27bb364ffdbfc10c33f7a2e82ae5a10f58119"
+  integrity sha512-LofN+5e/MKYrUAYkEvGQaPlcveBx0tclSXD16YQXig2SBmwnDze4oKSAIdda8fYQajrUjs17LfEuU1RR4eQsWQ==
 
 "@uncharted.software/css-options@^3.1.0":
   version "3.1.0"


### PR DESCRIPTION
### Description
Add path queries to the bio view. See attached screenshots for examples.

### Changes
- Upgrade bgraph library from v0.1.0 to v0.2.0. See release notes for changes: https://github.com/uncharted-aske/bgraph/releases/tag/v0.2.0
- Add path query execution builder to bgraph utils. **See consideration.**
- Refactored edge/node/path cases into their own utility for code clarity and de-duplication.
- Handle the results of a path query different from the results of an edge/node query. In a path query the bgraph query results are flattened to include the underlying path present within the Gremlin's state. In an edge/node query the underlying Gremlin's path state is ignored.
- A path query clause is broken up into a pre- path clause and a -post path clause before running the path query builder function. This is because to create an n-hop path query in bgraph you need to first filter down the result space using your "from" value in the query and then later on in the query select which results to store based on your "to" value. 

### Considerations
- **Design consideration:** When a user selects a path query, edge/node filters are treated as filters along each step of the path; pruning potential paths that do not satisfy the filters.
- Edge/Node filters are applied to every node/edge along the path; thus it is not possible via the current interface to make queries that have at least one node/edge along the path that fits a criteria. Additionally, any filter queries that only act on certain edges/nodes along the path are not possible via the current interface.
- The paths that get outputted have a maximum length of 6 hops. This value can be increased, however, it comes with a negative performance trade-off.

### Testing
- Ensure that you run `yarn install` prior to testing as the bgraph module has been updated from 0.1.0-> 0.2.0

### Screenshots
![Screen Shot 2021-06-18 at 4 17 24 PM](https://user-images.githubusercontent.com/15199528/122795750-a0809300-d28b-11eb-9136-fe0bb5dd5865.png)
![Screen Shot 2021-06-18 at 4 23 27 PM](https://user-images.githubusercontent.com/15199528/122795787-aa09fb00-d28b-11eb-9c42-42e810123731.png)
