### PR TITLE
Temporary models pane selector for variables and parameters

### DIFF
--- a/client/src/types/typesDonu.ts
+++ b/client/src/types/typesDonu.ts
@@ -8,7 +8,7 @@ enum RequestCommand {
   // GET_MODEL_SCHEMATIC = 'get-model-schematic',
   // GET_MODEL_SOURCE = 'get-model-source',
   LIST_MODELS = 'list-models',
-  SIMULATE = 'simulate',
+  SIMULATE = 'simulate-gsl',
   // UPLOAD_MODEL = 'upload-model',
 }
 

--- a/client/src/views/Simulation/components/ModelPanel.vue
+++ b/client/src/views/Simulation/components/ModelPanel.vue
@@ -34,6 +34,7 @@
         </button>
       </aside>
     </settings-bar>
+    <model-selector/>
     <global-graph v-if="model" :data="graph"/>
   </section>
 </template>
@@ -50,11 +51,13 @@
   import Counters from '@/components/Counters.vue';
   import SettingsBar from '@/components/SettingsBar.vue';
   import GlobalGraph from '@/views/Models/components/Graphs/GlobalGraph.vue';
+  import ModelSelector from '@/views/Simulation/components/ModelSelector.vue';
 
   const components = {
     Counters,
     GlobalGraph,
     SettingsBar,
+    ModelSelector,
   };
 
   // List of available graphs in a model

--- a/client/src/views/Simulation/components/ModelSelector.vue
+++ b/client/src/views/Simulation/components/ModelSelector.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="d-flex model-selector">
+    <div class="flex-grow-1">
+      <div class="button-group" v-for="(parameter) of getSimParameters" @click="clickHandler(parameter)" :key="parameter.name">
+        <input type="checkbox" class="mx-2" :checked="!parameter.hidden" />
+        <label>{{parameter.name}}</label>
+      </div>
+    </div>
+
+    <div class="flex-grow-1">
+      <div v-for="(variable) of getSimVariables" @click="clickHandler(variable)" :key="variable.name">
+        <input type="checkbox" class="mx-2" :checked="!variable.hidden" />
+        <label>{{variable.name}}</label>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+  import Vue from 'vue';
+  import Component from 'vue-class-component';
+  import { Getter } from 'vuex-class';
+  import * as HMI from '@/types/types';
+
+  @Component
+  export default class ModelSelector extends Vue {
+    @Getter getSimParameters;
+    @Getter getSimVariables;
+
+    clickHandler (parameter: HMI.SimulationParameter | HMI.SimulationVariable): void {
+      parameter.hidden = !parameter.hidden;
+    }
+  }
+</script>
+
+<style scoped>
+  .model-selector {
+    color: white;
+  }
+
+  .button-group {
+    cursor: pointer;
+  }
+</style>


### PR DESCRIPTION
Temporary fix addressing #228

Adds a small section to the models pane allowing the user to change which variables and parameters are hidden/visible. This is done to demonstrate the capability until a working model renderer is put into the simulate panel and the feature can be implemented for real.

Note that because of issues with accessing donu using the new gromet models, it will not be possible to test this PR unaltered. The PR was developed using an older version of the `main` branch. A small clip was made demonstrating the functionality to be added in this PR, PM me on slack for access to the clip due to github size constraints.

<img width="1792" alt="Screen Shot 2021-06-24 at 4 32 36 PM" src="https://user-images.githubusercontent.com/14062458/123329895-50afff00-d50b-11eb-9ade-1d397d65c077.png">
