### PR TITLE
Add runs counter to the simulation variables panel

### DIFF
--- a/client/src/components/SettingsBar.vue
+++ b/client/src/components/SettingsBar.vue
@@ -20,6 +20,7 @@
 
 .settings-bar-container {
   display: flex;
+  align-items: center;
   flex-shrink: 0;
   gap: 5px;
   justify-content: space-between;

--- a/client/src/views/Simulation/components/VariablesPanel.vue
+++ b/client/src/views/Simulation/components/VariablesPanel.vue
@@ -6,11 +6,16 @@
         :title="countersTitle"
         :data="countersData"
       />
-      <div slot="right">
-        <button type="button" disabled class="btn btn-secondary btn-settings">Settings</button>
-        <button type="button" class="btn btn-secondary py-0 btn-settings" @click="$emit('expand')">
-          <font-awesome-icon :icon="['fas', (expanded ? 'compress-alt' : 'expand-alt')]" />
-        </button>
+      <div class="d-flex align-items-center" slot="right">
+        <small class="mr-3 run-counter" v-if="getVariablesRunsCount">
+          {{`${getVariablesRunsCount} run${getVariablesRunsCount > 1 ? 's' : ''}`}}
+        </small>
+        <div class="btn-group">
+          <button type="button" disabled class="btn btn-secondary btn-settings">Settings</button>
+          <button type="button" class="btn btn-secondary py-0 btn-settings" @click="$emit('expand')">
+            <font-awesome-icon :icon="['fas', (expanded ? 'compress-alt' : 'expand-alt')]" />
+          </button>
+        </div>
       </div>
     </settings-bar>
 
@@ -183,6 +188,10 @@
   .btn-settings {
     height: 25px;
     line-height: 0;
+  }
+
+  .run-counter {
+    color: $text-color-light;
   }
 
   .chart {

--- a/client/src/views/Simulation/components/VariablesPanel.vue
+++ b/client/src/views/Simulation/components/VariablesPanel.vue
@@ -10,7 +10,7 @@
         <small class="mr-3 run-counter" v-if="getVariablesRunsCount">
           {{`${getVariablesRunsCount} run${getVariablesRunsCount > 1 ? 's' : ''}`}}
         </small>
-        <div class="btn-group">
+        <div>
           <button type="button" disabled class="btn btn-secondary btn-settings">Settings</button>
           <button type="button" class="btn btn-secondary py-0 btn-settings" @click="$emit('expand')">
             <font-awesome-icon :icon="['fas', (expanded ? 'compress-alt' : 'expand-alt')]" />


### PR DESCRIPTION
<img width="687" alt="Screen Shot 2021-06-28 at 2 42 21 PM" src="https://user-images.githubusercontent.com/14062458/123687648-29b14000-d81f-11eb-8b8e-c9e73d54b18f.png">

Fixes #230

Simple addition which adds a run counter to the variables panel. The light-mode mock up uses grey text, but since I didn't find that looked great on a dark theme, I went with making the text smaller to de-emphasize it while keeping the text colour the same as everything else. The other option is to keep the text the same size and colour as everything else which I think looks fine too. Thoughts?

Note: Again because of Donu difficulties, this will not work out-of-the-gate either if you wish to test it yourself. An easy way to rig it so that works is just to replace references to `getVariablesRunsCount` in the code with some integer.