### PR TITLE
Hook up node click event for Global Graph in the Models view

### DIFF
--- a/client/src/graphs/svg/elk/adapter.js
+++ b/client/src/graphs/svg/elk/adapter.js
@@ -18,7 +18,7 @@ const build = (root) => {
       depth: depth,
       type: 'normal',
       parent: parent,
-      data: node.data,
+      data: node.data || node,
     };
 
     // Build edges
@@ -80,7 +80,7 @@ const injectELKOptions = (renderGraph, options) => {
       node.height = node.height || options.nodeHeight;
 
       // Special case for parameters
-      if (node.data.role?.includes('parameter')) {
+      if (node.data && node.data.role?.includes('parameter')) {
         node.width = options.parameterNodeSize || 30;
         node.height = options.parameterNodeSize || 30;
       }

--- a/client/src/types/typesGraphs.ts
+++ b/client/src/types/typesGraphs.ts
@@ -63,6 +63,8 @@ export interface GraphNodeInterface {
   dataType?:string,
   data?: GraphNodeDataInterface,
   metadata?: any,
+  parent?: string,
+  role?: string[],
 }
 
 export interface GraphEdgeInterface {

--- a/client/src/views/Graphs/components/Graphs/LocalGraph.vue
+++ b/client/src/views/Graphs/components/Graphs/LocalGraph.vue
@@ -11,7 +11,6 @@
 
   import BioLocalRenderer from '@/graphs/svg/renderers/BioLocalRenderer';
   import ELKAdapter from '@/graphs/svg/elk/adapter';
-  import { layered } from '@/graphs/svg/elk/layouts';
   import { calculateNodeNeighborhood, calculateEdgeNeighborhood } from '@/graphs/svg/util';
 
   const DEFAULT_RENDERING_OPTIONS = {

--- a/client/src/views/Graphs/components/Graphs/LocalGraph.vue
+++ b/client/src/views/Graphs/components/Graphs/LocalGraph.vue
@@ -10,14 +10,13 @@
   import { GraphInterface } from '@/types/typesGraphs';
 
   import BioLocalRenderer from '@/graphs/svg/renderers/BioLocalRenderer';
-  import Adapter from '@/graphs/svg/elk/adapter';
+  import ELKAdapter from '@/graphs/svg/elk/adapter';
   import { layered } from '@/graphs/svg/elk/layouts';
   import { calculateNodeNeighborhood, calculateEdgeNeighborhood } from '@/graphs/svg/util';
 
   const DEFAULT_RENDERING_OPTIONS = {
     nodeWidth: 120,
     nodeHeight: 40,
-    layout: layered,
   };
 
   @Component
@@ -35,7 +34,7 @@
     mounted (): void {
       this.renderer = new BioLocalRenderer({
         el: this.$refs.graph,
-        adapter: new Adapter(DEFAULT_RENDERING_OPTIONS),
+        adapter: new ELKAdapter(DEFAULT_RENDERING_OPTIONS),
         renderMode: 'basic',
         useEdgeControl: true,
         edgeControlOffset: 0.5,

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -323,7 +323,7 @@
       this.drilldownActiveTabId = 'metadata';
 
       this.drilldownPaneTitle = node.label;
-      this.drilldownPaneSubtitle = node.nodeType;
+      this.drilldownPaneSubtitle = `${node.nodeType} (${node.dataType})`;
       this.drilldownMetadata = node.metadata;
 
       // const nodeMetadata = node.metadata;

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -324,7 +324,7 @@
 
       this.drilldownPaneTitle = node.label;
       this.drilldownPaneSubtitle = node.nodeType;
-      this.drilldownMetadata = node.metadata; 
+      this.drilldownMetadata = node.metadata;
 
       // const nodeMetadata = node.metadata;
       // if (nodeMetadata) {

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -324,7 +324,7 @@
 
       this.drilldownPaneTitle = node.label;
       this.drilldownPaneSubtitle = node.nodeType;
-      this.drilldownMetadata = null;
+      this.drilldownMetadata = node.metadata; 
 
       // const nodeMetadata = node.metadata;
       // if (nodeMetadata) {

--- a/client/src/views/Models/components/Graphs/GlobalGraph.vue
+++ b/client/src/views/Models/components/Graphs/GlobalGraph.vue
@@ -81,7 +81,7 @@
           const neighborhood = calculateNodeNeighborhood(this.data, node.datum());
           this.renderer.highlight(neighborhood, { color: Colors.HIGHLIGHT, duration: 5000 });
 
-          this.$emit('node-click', node.datum());
+          this.$emit('node-click', node.datum().data);
         }
       });
 

--- a/client/src/views/Models/components/Graphs/GlobalGraph.vue
+++ b/client/src/views/Models/components/Graphs/GlobalGraph.vue
@@ -80,6 +80,8 @@
         } else {
           const neighborhood = calculateNodeNeighborhood(this.data, node.datum());
           this.renderer.highlight(neighborhood, { color: Colors.HIGHLIGHT, duration: 5000 });
+
+          this.$emit('node-click', node.datum());
         }
       });
 

--- a/client/src/views/Models/components/Graphs/LocalGraph.vue
+++ b/client/src/views/Models/components/Graphs/LocalGraph.vue
@@ -11,10 +11,8 @@
   import { highlight } from 'svg-flowgraph';
 
   import { GraphInterface } from '@/types/typesGraphs';
-
   import EpiRenderer from '@/graphs/svg/renderers/EpiRenderer';
   import Adapter from '@/graphs/svg/elk/adapter';
-  import { layered } from '@/graphs/svg/elk/layouts';
   import { showTooltip, hideTooltip } from '@/utils/SVGUtil.js';
   import { calculateNodeNeighborhood } from '@/graphs/svg/util.js';
   import { Colors } from '@/graphs/svg/encodings';
@@ -22,7 +20,6 @@
   const DEFAULT_RENDERING_OPTIONS = {
     nodeWidth: 120,
     nodeHeight: 40,
-    layout: layered,
   };
 
   @Component


### PR DESCRIPTION
**What**

- Added `node-click` event for the `GlobalGraph.vue` in the Models view (for the demo in February) we were only allowing drilling down operations from the `LocalGraph` but that has been removed and now the split view is used for simulation. 
- Update local graph in the `Graphs` space that got outdated with the latest changes in the graph adapters.

**Screenshots**
![image](https://user-images.githubusercontent.com/10552785/123707714-22e2f700-d838-11eb-905c-f1e885babefb.png)

**To test**

- Select the SIR model and click on a specific node using any of the modeling frameworks.
- The drilldown panel should open and show the node title, node type and data type. 
- The rest of collapsible panels are empty but we should be able to populate them with the new `metadata` we receive in GroMets.




