### PR TITLE
Metadata panel for model nodes

### DIFF
--- a/client/src/filters/CapitalizeFormatter.ts
+++ b/client/src/filters/CapitalizeFormatter.ts
@@ -1,0 +1,4 @@
+export default (value:string):string => {
+  return value.charAt(0).toLocaleUpperCase()
+    .concat(value.slice(1).toLocaleLowerCase());
+};

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -35,6 +35,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import CapitalizeFirstLetterFormatter from './filters/CapitalizeFirstLetterFormatter';
 import UnderscoreRemoverFormatter from './filters/UnderscoreRemoverFormatter';
 import RemoveBracesFormatter from './filters/RemoveBracesFormatter';
+import CapitalizeFormatter from './filters/CapitalizeFormatter';
 import PrecisionFormatter from './filters/PrecisionFormatter';
 import ArrayToList from './filters/ArrayToListFormatter';
 
@@ -86,6 +87,7 @@ Vue.component('font-awesome-icon', FontAwesomeIcon);
 Vue.filter('CapitalizeFirstLetterFormatter', CapitalizeFirstLetterFormatter);
 Vue.filter('UnderscoreRemoverFormatter', UnderscoreRemoverFormatter);
 Vue.filter('RemoveBracesFormatter', RemoveBracesFormatter);
+Vue.filter('CapitalizeFormatter', CapitalizeFormatter);
 Vue.filter('PrecisionFormatter', PrecisionFormatter);
 Vue.filter('ArrayToList', ArrayToList);
 

--- a/client/src/styles/aske.scss
+++ b/client/src/styles/aske.scss
@@ -3,3 +3,4 @@
 @import "overrides";
 @import "nord";
 @import "colours";
+@import "metadata";

--- a/client/src/styles/metadata.scss
+++ b/client/src/styles/metadata.scss
@@ -1,0 +1,75 @@
+/** Metadata using <details> */
+
+/* Display the metadata in in a vertical list */
+.metadata-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  padding: 1em 0;
+}
+
+.metadata,
+.metadata details {
+  border: var(--border);
+  border-radius: .2em;
+}
+
+.metadata-content {
+  hyphens: auto;
+  overflow-wrap: break-word;
+  padding-left: .5em;
+  padding-right: .5em;
+  text-align: left;
+  word-wrap: break-word;
+}
+
+.metadata summary {
+  padding: .5em;
+}
+
+.metadata > summary {
+  background-color: var(--drilldown-header);
+  font-weight: bold;
+}
+
+.metadata[open] > summary,
+.metadata details[open] > summary {
+  border-bottom: var(--border);
+  margin-bottom: .5em;
+}
+
+.metadata h6 {
+  display: block;
+  font-weight: bold;
+  margin: 0;
+
+  &:not(:first-of-type) {
+    margin-top: 1em;
+  }
+
+  & + p {
+    margin: 0;
+  }
+}
+
+.metadata ol {
+  list-style-position: inside;
+  list-style-type: lower-roman;
+  margin: 0;
+  padding: 0;
+}
+
+/* If a details is within a metadata. */
+.metadata details {
+  padding: .5em;
+  margin: .5em;
+}
+
+.metadata-provenance {
+  font-size: .8em;
+  font-style: italic;
+  padding: .5rem;
+  text-align: right;
+
+  time { display: block; }
+}

--- a/client/src/types/typesGroMEt.ts
+++ b/client/src/types/typesGroMEt.ts
@@ -2,8 +2,10 @@
  * Define Types used for GroMET
  */
 
+/* eslint-disable camelcase */
+
 type Provenance = {
-  metadata_type: string, // eslint-disable-line
+  metadata_type: string,
   method: string,
   timestamp: string,
 };
@@ -14,20 +16,26 @@ type FileId = {
   uid: string,
 }
 
+export enum CodeType {
+  CodeBlock = 'CODE_BLOCK',
+  Identifier = 'IDENTIFIER',
+}
+
 export enum MetadateType {
   ModelInterface = 'ModelInterface',
   CodeCollectionReference = 'CodeCollectionReference',
+  CodeSpanReference = 'CodeSpanReference',
   TextualDocumentReferenceSet = 'TextualDocumentReferenceSet',
 }
 
 export interface Metadata {
-  metadata_type: MetadateType, // eslint-disable-line
+  metadata_type: MetadateType,
   provenance: Provenance,
   uid: string,
 }
 
 export interface ModelInterface extends Metadata {
-  initial_conditions: Record<number, string>[], // eslint-disable-line
+  initial_conditions: Record<number, string>[],
   parameters: Record<number, string>[],
   variables: Record<number, string>[],
 }
@@ -35,6 +43,15 @@ export interface ModelInterface extends Metadata {
 export interface CodeCollectionInterface extends Metadata {
   fileIds: FileId[],
   globalReferenceId: {id: string, type: string},
+}
+
+export interface CodeSpanReference extends Metadata {
+  code_type: CodeType,
+  file_id: string,
+  line_begin: number,
+  line_end: number,
+  col_begin: number,
+  col_end: number,
 }
 
 export interface TextualDocumentReferenceSet extends Metadata {

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -50,7 +50,7 @@
       </div>
     </div>
     <drilldown-panel @close-pane="onCloseDrilldownPanel" :tabs="drilldownTabs" :active-tab-id="drilldownActiveTabId" :is-open="isOpenDrilldown" :pane-title="drilldownPaneTitle" :pane-subtitle="drilldownPaneSubtitle" @tab-click="onDrilldownTabClick">
-      <metadata-pane v-if="drilldownActiveTabId === 'metadata'" slot="content" :metadata="drilldownMetadata" @open-modal="onOpenModalMetadata"/>
+      <metadata-pane v-if="drilldownActiveTabId === 'metadata'" slot="content" :data="drilldownMetadata" @open-modal="onOpenModalMetadata"/>
       <parameters-pane v-if="drilldownActiveTabId === 'parameters'" slot="content" :data="drilldownParameters" :related="drilldownRelatedParameters" @open-modal="onOpenModalParameters"/>
       <knowledge-pane v-if="drilldownActiveTabId === 'knowledge'" slot="content" :data="drilldownKnowledge"/>
     </drilldown-panel>
@@ -324,18 +324,6 @@
       this.drilldownPaneTitle = node.label;
       this.drilldownPaneSubtitle = `${node.nodeType} (${node.dataType})`;
       this.drilldownMetadata = node.metadata;
-
-      // const nodeMetadata = node.metadata;
-      // if (nodeMetadata) {
-      //   const nodeKnowledge = { knowledge: bakedData.success.data }; // To show some text snippets
-      //   this.drilldownMetadata = Object.assign({}, nodeKnowledge, nodeMetadata);
-
-      //   // This probably will need to be refactored since we don't want to do all the queries at the same time, just on demand given the active tab
-      //   const textDefinition = nodeMetadata.attributes[0].text_definition;
-      //   this.formatParametersData();
-      //   this.getRelatedParameters(textDefinition);
-      //   this.searchCosmos(textDefinition);
-      // }
     }
 
     async getSingleArtifact (id: string):Promise<CosmosSearchInterface> {

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -50,7 +50,7 @@
       </div>
     </div>
     <drilldown-panel @close-pane="onCloseDrilldownPanel" :tabs="drilldownTabs" :active-tab-id="drilldownActiveTabId" :is-open="isOpenDrilldown" :pane-title="drilldownPaneTitle" :pane-subtitle="drilldownPaneSubtitle" @tab-click="onDrilldownTabClick">
-      <metadata-pane v-if="drilldownActiveTabId === 'metadata'" slot="content" :data="drilldownMetadata" @open-modal="onOpenModalMetadata"/>
+      <metadata-pane v-if="drilldownActiveTabId === 'metadata'" slot="content" :metadata="drilldownMetadata" @open-modal="onOpenModalMetadata"/>
       <parameters-pane v-if="drilldownActiveTabId === 'parameters'" slot="content" :data="drilldownParameters" :related="drilldownRelatedParameters" @open-modal="onOpenModalParameters"/>
       <knowledge-pane v-if="drilldownActiveTabId === 'knowledge'" slot="content" :data="drilldownKnowledge"/>
     </drilldown-panel>

--- a/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
+++ b/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
@@ -53,10 +53,7 @@
   export default class MetadataPane extends Vue {
     @Prop({ default: null }) data: any[];
 
-    /** Clean the metadata to match our expected format.
-     * TODO: This is a temporary solution and should be replaced with
-     * a proper formatter when DONU is fully implemented.
-     */
+    /** Clean the metadata to match our expected format. */
     get metadata () : GroMET.CodeSpanReference[] {
       if (!this.data) return [];
       const cleanMetadata = this.data.map(datum => {

--- a/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
+++ b/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="metadata-list">
-    <div v-if="isEmptyMetadata" class="alert alert-info" role="alert">
+    <div v-if="isEmptyMetadata" class="alert alert-info">
       No metadata at the moment
     </div>
 
@@ -9,118 +9,102 @@
       v-else
       v-for="(datum, index) in metadata" :key="index"
     >
-
-      <template>
-        <summary>Type</summary>
+      <template v-if="isTypeCodeSpanReference(datum)">
+        <summary :title="datum.uid">Code Reference</summary>
         <div class="metadata-content">
-          {{getType}}
+          <h6>Type</h6>
+          <p>{{ datum.code_type | capitalize-formatter }}</p>
+          <h6>File</h6>
+          <p>
+            <a :href="datum.file_id">{{ datum.file_id }}</a><br>
+            {{ sourceFilePosition(datum) }}
+          </p>
         </div>
       </template>
 
-      <template>
-        <summary>Provenance</summary>
-        <div class="metadata-content">
-            <div v-for="(value, key) in getProvenance" :key="key">
-              <div class="key">{{key | capitalize-first-letter-formatter}}</div>
-              <div v-if="key !== 'sources'">{{value}}</div>
-              <div v-else>
-                <div v-for="(source, key) in value[0]" :key="key">
-                    {{source}}
-                  </div>
-              </div>
-            </div>
-        </div>
-      </template>
-
-      <template>
-        <summary>Attributes</summary>
-        <div class="metadata-content">
-            <div v-for="(item, index) in getAttributes" :key="index">
-              <div v-for="(value, key) in item" :key="key">
-              <div class="key">{{key | capitalize-first-letter-formatter}}</div>
-                {{value}}
-              </div>
-            </div>
-        </div>
-      </template>
-
-      <template>
-        <summary>Text Snippets</summary>
-        <div class="metadata-content">
-          <div v-for="(item, index) in getKnowledge" :key="index" class="snippet-container" @click="showMoreHandler(item.doi)">
-            <div class="snippet-title">
-              <a target="_blank" :href="item.URL">{{item.title}}</a>
-            </div>
-            <span v-for="(snippet, index) in item.highlight" :key="index" v-html="snippet" class="snippet-highlights"/>
-          </div>
-        </div>
-      </template>
-
+      <aside class="metadata-provenance">
+        {{ datum.provenance.method }}
+        <time :datetime="datum.provenance.timestamp">
+          {{ provenanceDate(datum.provenance.timestamp) }}
+        </time>
+      </aside>
     </details>
   </div>
 </template>
 
 <script lang="ts">
-  import _ from 'lodash';
-
-  import Component from 'vue-class-component';
   import Vue from 'vue';
+  import Component from 'vue-class-component';
   import { Prop } from 'vue-property-decorator';
 
-  import { CosmosTextSnippet } from '@/types/typesCosmos';
+  import * as GroMET from '@/types/typesGroMEt';
+  import { formatFullDateTime } from '@/utils/DateTimeUtil';
+
+  const defaultCodeSpanReference: any = {
+    code_type: GroMET.CodeType.Identifier,
+    file_id: null,
+    line_begin: null,
+    line_end: null,
+    col_begin: null,
+    col_end: null,
+  };
 
   @Component
   export default class MetadataPane extends Vue {
-    @Prop({ default: null }) data: any;
+    @Prop({ default: null }) data: any[];
 
-    showModal: boolean = false;
-    dataLoading = false;
+    /** Clean the metadata to match our expected format.
+     * TODO: This is a temporary solution and should be replaced with
+     * a proper formatter when DONU is fully implemented.
+     */
+    get metadata () : GroMET.CodeSpanReference[] {
+      if (!this.data) return [];
+      const cleanMetadata = this.data.map(datum => {
+        return { ...defaultCodeSpanReference, ...datum };
+      });
+      return cleanMetadata;
+    }
 
     get isEmptyMetadata (): boolean {
-      return _.isEmpty(this.data);
+      return this.metadata.length === 0;
     }
 
-    get getType (): string {
-      return !_.isEmpty(this.data) && this.data.type;
+    isTypeCodeSpanReference (datum: GroMET.Metadata): boolean {
+      return datum.metadata_type === GroMET.MetadateType.CodeSpanReference;
     }
 
-    get getProvenance (): any {
-      return !_.isEmpty(this.data) && this.data.provenance;
-    }
-
-    get getAttributes (): any {
-      return !_.isEmpty(this.data) && this.data.attributes;
-    }
-
-    get getTextDefinition (): string {
-      return (!_.isEmpty(this.data) && !_.isEmpty(this.data.attributes[0].text_definition)) && this.data.attributes[0].text_definition;
-    }
-
-    get getKnowledge (): CosmosTextSnippet[] {
-      return !_.isEmpty(this.data) && this.data.knowledge && this.data.knowledge.map(d => _.pick(d, ['doi', 'title', 'URL', 'highlight', 'doi']));
+    provenanceDate (timestamp: string): string {
+      return formatFullDateTime(timestamp);
     }
 
     showMoreHandler (doi: string): void {
       this.$emit('open-modal', doi);
     }
+
+    sourceFilePosition (datum: GroMET.CodeSpanReference): string {
+      let lines: string, columns: string;
+
+      if (datum.line_begin) {
+        lines = `Line #${datum.line_begin}`;
+      }
+
+      if (datum.line_end) {
+        lines = lines
+          ? `Lines #${datum.line_begin}-${datum.line_end}`
+          : `Line #${datum.line_end}`;
+      }
+
+      if (datum.col_begin) {
+        columns = `Column #${datum.col_begin}`;
+      }
+
+      if (datum.col_end) {
+        columns = columns
+          ? `Columns #${datum.col_begin}-${datum.col_end}`
+          : `Column #${datum.col_end}`;
+      }
+
+      return `${lines} ${columns}`.trim();
+    }
   }
 </script>
-
-<style scoped>
-.snippet-container {
-  height: 100%;
-  overflow: auto;
-  border: var(--border);
-  padding: 4px 8px;
-  box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
-  cursor: pointer;
-}
-
-.snippet-highlights {
-  font-size: 14px;
-}
-
-.snippet-highlights em {
-  font-weight: bold;
-}
-</style>

--- a/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
+++ b/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
@@ -1,61 +1,63 @@
 <template>
-  <collapsible-container :isEmpty="isEmptyMetadata">
-    <collapsible-item slot="item">
-      <div slot="title">Type</div>
-      <div slot="content">
-        <div class="metadata-item">
-            {{getType}}
-        </div>
-      </div>
-    </collapsible-item>
-
-    <collapsible-item slot="item">
-      <div slot="title">Provenance</div>
-      <div slot="content">
-        <div class="metadata-item">
-          <div v-for="(value, key) in getProvenance" :key="key">
-            <div class="key">{{key | capitalize-first-letter-formatter}}</div>
-            <div v-if="key !== 'sources'">{{value}}</div>
-            <div v-else>
-              <div v-for="(source, key) in value[0]" :key="key">
-                  {{source}}
-                </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </collapsible-item>
-
-    <collapsible-item slot="item">
-      <div slot="title">Attributes</div>
-      <div slot="content">
-        <div class="metadata-item">
-          <div v-for="(item, index) in getAttributes" :key="index">
-            <div v-for="(value, key) in item" :key="key">
-            <div class="key">{{key | capitalize-first-letter-formatter}}</div>
-              {{value}}
-            </div>
-          </div>
-        </div>
-      </div>
-    </collapsible-item>
-
-    <collapsible-item slot="item" class="flex-grow-1">
-      <div slot="title">Text Snippets</div>
-      <div slot="content" class="h-100 position-absolute">
-        <div v-for="(item, index) in getKnowledge" :key="index" class="snippet-container" @click="showMoreHandler(item.doi)">
-          <div class="snippet-title">
-            <a target="_blank" :href="item.URL">{{item.title}}</a>
-          </div>
-          <span v-for="(snippet, index) in item.highlight" :key="index" v-html="snippet" class="snippet-highlights"/>
-        </div>
-      </div>
-    </collapsible-item>
-
-    <div slot="empty" class="alert alert-info" role="alert">
+  <div class="metadata-list">
+    <div v-if="isEmptyMetadata" class="alert alert-info" role="alert">
       No metadata at the moment
     </div>
-  </collapsible-container>
+
+    <details
+      class="metadata" open
+      v-else
+      v-for="(datum, index) in metadata" :key="index"
+    >
+
+      <template>
+        <summary>Type</summary>
+        <div class="metadata-content">
+          {{getType}}
+        </div>
+      </template>
+
+      <template>
+        <summary>Provenance</summary>
+        <div class="metadata-content">
+            <div v-for="(value, key) in getProvenance" :key="key">
+              <div class="key">{{key | capitalize-first-letter-formatter}}</div>
+              <div v-if="key !== 'sources'">{{value}}</div>
+              <div v-else>
+                <div v-for="(source, key) in value[0]" :key="key">
+                    {{source}}
+                  </div>
+              </div>
+            </div>
+        </div>
+      </template>
+
+      <template>
+        <summary>Attributes</summary>
+        <div class="metadata-content">
+            <div v-for="(item, index) in getAttributes" :key="index">
+              <div v-for="(value, key) in item" :key="key">
+              <div class="key">{{key | capitalize-first-letter-formatter}}</div>
+                {{value}}
+              </div>
+            </div>
+        </div>
+      </template>
+
+      <template>
+        <summary>Text Snippets</summary>
+        <div class="metadata-content">
+          <div v-for="(item, index) in getKnowledge" :key="index" class="snippet-container" @click="showMoreHandler(item.doi)">
+            <div class="snippet-title">
+              <a target="_blank" :href="item.URL">{{item.title}}</a>
+            </div>
+            <span v-for="(snippet, index) in item.highlight" :key="index" v-html="snippet" class="snippet-highlights"/>
+          </div>
+        </div>
+      </template>
+
+    </details>
+  </div>
 </template>
 
 <script lang="ts">
@@ -65,16 +67,9 @@
   import Vue from 'vue';
   import { Prop } from 'vue-property-decorator';
 
-  import CollapsibleContainer from '@/components/Collapsible/CollapsibleContainer.vue';
-  import CollapsibleItem from '@/components/Collapsible/CollapsibleItem.vue';
   import { CosmosTextSnippet } from '@/types/typesCosmos';
 
-  const components = {
-    CollapsibleContainer,
-    CollapsibleItem,
-  };
-
-  @Component({ components })
+  @Component
   export default class MetadataPane extends Vue {
     @Prop({ default: null }) data: any;
 
@@ -111,34 +106,21 @@
   }
 </script>
 
-<style lang="scss" scoped>
-@import "@/styles/variables";
-
-.metadata-item {
-  overflow-wrap: break-word;
-  word-wrap: break-word;
-  hyphens: auto;
-  text-align: left;
-  margin-top: 5px;
-  padding: 5px;
-  .key {
-    font-weight: bold;
-    padding-top: 5px;
-  }
-}
-
+<style scoped>
 .snippet-container {
   height: 100%;
   overflow: auto;
-  border: 1px solid $border;
+  border: var(--border);
   padding: 4px 8px;
   box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
   cursor: pointer;
-  .snippet-highlights {
-    font-size: 14px;
-    em {
-      font-weight: bold;
-    }
-  }
+}
+
+.snippet-highlights {
+  font-size: 14px;
+}
+
+.snippet-highlights em {
+  font-weight: bold;
 }
 </style>

--- a/client/src/views/Models/components/MetadataPanel.vue
+++ b/client/src/views/Models/components/MetadataPanel.vue
@@ -1,46 +1,55 @@
 <template>
-  <div class="metadata-panel">
-    <details v-for="(datum, index) in metadata" :key="index" open>
+  <div class="metadata-panel metadata-list">
+    <details
+      class="metadata" open
+      v-for="(datum, index) in metadata" :key="index"
+    >
 
       <template v-if="isTypeModel(datum)">
         <summary :title="datum.uid">Model</summary>
-        <span>Variables</span>
-        <p>{{ datum.variables | ArrayToList }}</p>
-        <span>Parameters</span>
-        <p>{{ datum.parameters | ArrayToList }}</p>
-        <span>Initial Conditions</span>
-        <p>{{ datum.initial_conditions | ArrayToList }}</p>
+        <div class="metadata-content">
+          <h6>Variables</h6>
+          <p>{{ datum.variables | ArrayToList }}</p>
+          <h6>Parameters</h6>
+          <p>{{ datum.parameters | ArrayToList }}</p>
+          <h6>Initial Conditions</h6>
+          <p>{{ datum.initial_conditions | ArrayToList }}</p>
+        </div>
       </template>
 
       <template v-else-if="isTypeCode(datum)">
         <summary :title="datum.uid">Code</summary>
-        <span>Reference</span>
-        <p>{{ datum.global_reference_id.type }} {{ datum.global_reference_id.id }}</p>
-        <span>Files</span>
-        <ol>
-          <li
-            v-for="(file, index) in datum.file_ids"
-            :key="index"
-            :title="file.uid"
-          >{{ file.name }} ({{ file.path }})</li>
-        </ol>
+        <div class="metadata-content">
+          <h6>Reference</h6>
+          <p>{{ datum.global_reference_id.type }} {{ datum.global_reference_id.id }}</p>
+          <h6>Files</h6>
+          <ol>
+            <li
+              v-for="(file, index) in datum.file_ids"
+              :key="index"
+              :title="file.uid"
+            >{{ file.name }} ({{ file.path }})</li>
+          </ol>
+        </div>
       </template>
 
       <template v-else-if="isTypeDocuments(datum)">
         <summary :title="datum.uid">Documents</summary>
-        <details v-for="(doc, index) in datum.documents" :key="index">
-          <summary :title="doc.uid">
-            <a :href="doc.bibjson.website.url">{{ doc.bibjson.title }}</a>
-            {{ doc.global_reference_id.type }} {{ doc.global_reference_id.id }}
-          </summary>
-          <span>File</span>
-          <p><a :href="doc.bibjson.file_url">{{ doc.bibjson.file }}</a></p>
-          <span>Author(s)</span>
-          <p>{{ doc.bibjson.author.map(a => a.name) | ArrayToList }}</p>
-        </details>
+        <div class="metadata-content">
+          <details v-for="(doc, index) in datum.documents" :key="index">
+            <summary :title="doc.uid">
+              <a :href="doc.bibjson.website.url">{{ doc.bibjson.title }}</a>
+              {{ doc.global_reference_id.type }} {{ doc.global_reference_id.id }}
+            </summary>
+            <h6>File</h6>
+            <p><a :href="doc.bibjson.file_url">{{ doc.bibjson.file }}</a></p>
+            <h6>Author(s)</h6>
+            <p>{{ doc.bibjson.author.map(a => a.name) | ArrayToList }}</p>
+          </details>
+        </div>
       </template>
 
-      <aside class="provenance">
+      <aside class="metadata-provenance">
         {{ datum.provenance.method }}
         <time :datetime="datum.provenance.timestamp">
           {{ provenanceDate(datum.provenance.timestamp) }}
@@ -79,73 +88,3 @@
     }
   }
 </script>
-
-<style lang="scss" scoped>
-  .metadata-panel {
-    display: flex;
-    flex-direction: column;
-    gap: 1em;
-    padding: 1em 0;
-  }
-
-  .metadata-panel > details {
-    & > *:not(summary, .provenance) {
-      padding-left: .5em;
-      padding-right: .5em;
-    }
-
-    & > summary {
-      background-color: var(--drilldown-header);
-      font-weight: bold;
-    }
-  }
-
-  details {
-    border: var(--border);
-    border-radius: .2em;
-  }
-
-  details > summary {
-    padding: .5em;
-  }
-
-  details[open] > summary {
-    border-bottom: var(--border);
-    margin-bottom: .5em;
-  }
-
-  details details {
-    padding: .5em;
-    margin: .5em;
-  }
-
-  .provenance {
-    font-size: .8em;
-    font-style: italic;
-    padding: .5rem;
-    text-align: right;
-
-    time { display: block; }
-  }
-
-  details > span {
-    display: block;
-    font-weight: bold;
-    margin: 0;
-
-    &:not(:first-of-type) {
-      margin-top: 1em;
-    }
-  }
-
-  ol {
-    list-style-position: inside;
-    list-style-type: lower-roman;
-    margin: 0;
-    padding: 0;
-  }
-
-  p {
-    margin: 0;
-  }
-</style>


### PR DESCRIPTION
**What**
 - Display the metadata provided by GroMET on a _Computational Model_.

**How** 
- Created a new Vue Filter to capitalize text;
- Separated the metadata styling out of the models' components into a separate stylesheet;
- Created a new GroMET interface to handle `CodeSpanReference` metadata type;
- Tidy up the _Models_ view metadata panes to be identical; and
- Clean unused code.

**Testing**
 - Select and open a _Computational Model_ 
 - Click on a node, either in _Petri Net Classic_ or _Functional Network_ modelling framework
 - Make sure the `drilldown-panel` open on the right with the `metadata` pane open
 - See if the *Code Reference* metadata and provenance are displayed like in the screenshot.
 - If there is no metadata available, a message should be displayed

**Screenshot**

![Screen Shot 2021-07-02 at 15 33 39](https://user-images.githubusercontent.com/636801/124320988-e589ac80-db4a-11eb-9c7e-22baf48bc578.png)

**Anything else**
1. Right now we get minimum information from GroMET.

```JSON
    "metadata": [
        {
          "metadata_type": "CodeSpanReference",
          "uid": "code_s_in",
          "provenance": {
            "metadata_type": "Provenance",
            "method": "Manual_claytonm@az",
            "timestamp": "2021-06-18T05:44:54:405667_MST-0700"
          },
          "code_type": "IDENTIFIER",
          "file_id": "simple_sir_code",
          "line_begin": 31,
          "line_end": null,
          "col_begin": 9,
          "col_end": null
        }
      ],
```
2. Once we have access to the code source files, we will display snippets of the code.