### PR TITLE
Add neighbors to node panel of bio subgraph

### DIFF
--- a/client/src/components/Collapsible/CollapsibleItem.vue
+++ b/client/src/components/Collapsible/CollapsibleItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="collapsible-item">
+  <div :class="`collapsible-item ${expandedState && grow ? 'flex-grow-1' : ''}`">
     <div class="item-container">
       <div
         class="item-title"
@@ -40,6 +40,7 @@
   @Component
   export default class CollapsibleItem extends Vue {
     @Prop({ default: false }) expanded: boolean;
+    @Prop({ default: false }) grow: boolean;
     expandedState: boolean = false;
 
     @Watch('expanded') onExpandedChange (): void {

--- a/client/src/views/Graphs/Graph.vue
+++ b/client/src/views/Graphs/Graph.vue
@@ -237,6 +237,8 @@
     }
 
     async mounted (): Promise<void> {
+      eventHub.$on('get-bgraph', cb => cb(this.bgraphInstance));
+
       // Load the graph only if we have a selected model,
       // otherwise wait until the getKnowledgeGraphsList as loaded.
       if (this.selectedGraph) {

--- a/client/src/views/Graphs/components/DrilldownPanel/NodePane.vue
+++ b/client/src/views/Graphs/components/DrilldownPanel/NodePane.vue
@@ -104,7 +104,7 @@
             .unique()
             .run()
             .filter(node => !subgraph.has(node.vertex.id))
-            .map(node => `${node.vertex.name} → ${this.data.label}`);
+            .map(node => `${this.data.label} → ${node.vertex.name}`);
           this.incomingNodes = bgraph
             .v({ id: this.data.id })
             .in()
@@ -112,7 +112,7 @@
             .unique()
             .run()
             .filter(node => !subgraph.has(node.vertex.id))
-            .map(node => `${this.data.label} → ${node.vertex.name}`);
+            .map(node => `${node.vertex.name} → ${this.data.label}`);
         }
       });
     }

--- a/client/src/views/Graphs/components/DrilldownPanel/NodePane.vue
+++ b/client/src/views/Graphs/components/DrilldownPanel/NodePane.vue
@@ -19,7 +19,7 @@
       </details>
 
       <details v-if="data.in_degree" class="metadata" open>
-        <summary>Incoming ({{ data.in_degree }})</summary>
+        <summary>{{ `Incoming ${incoming.length} / ${data.in_degree}` }}</summary>
         <div class="metadata-content">
           <div role="button" class="mb-1 p-2 rounded-lg border" v-for="(rowLabel, index) in incoming" :key="index">
             {{rowLabel}}
@@ -31,7 +31,7 @@
       </details>
 
       <details v-if="data.out_degree" class="metadata" open>
-        <summary>Outgoing ({{ data.out_degree }})</summary>
+        <summary>{{ `Outgoing ${outgoing.length} / ${data.out_degree}` }}</summary>
         <div class="metadata-content">
           <div role="button" class="mb-1 p-2 rounded-lg border" v-for="(rowLabel, index) in outgoing" :key="index">
             {{rowLabel}}

--- a/client/src/views/Graphs/components/DrilldownPanel/NodePane.vue
+++ b/client/src/views/Graphs/components/DrilldownPanel/NodePane.vue
@@ -21,7 +21,7 @@
       <details v-if="data.in_degree" class="metadata" open>
         <summary>Incoming ({{ data.in_degree }})</summary>
         <div class="metadata-content">
-          <div class="mb-1 p-2 rounded-lg border" v-for="(rowLabel, index) in incoming" :key="index">
+          <div role="button" class="mb-1 p-2 rounded-lg border" v-for="(rowLabel, index) in incoming" :key="index">
             {{rowLabel}}
           </div>
           <button type="button" class="btn btn-sm btn-light" @click="viewAllIncoming">
@@ -33,7 +33,7 @@
       <details v-if="data.out_degree" class="metadata" open>
         <summary>Outgoing ({{ data.out_degree }})</summary>
         <div class="metadata-content">
-          <div class="mb-1 p-2 rounded-lg border" v-for="(rowLabel, index) in outgoing" :key="index">
+          <div role="button" class="mb-1 p-2 rounded-lg border" v-for="(rowLabel, index) in outgoing" :key="index">
             {{rowLabel}}
           </div>
           <button type="button" class="btn btn-sm btn-light" @click="viewAllOutgoing">

--- a/client/src/views/Graphs/components/DrilldownPanel/NodePane.vue
+++ b/client/src/views/Graphs/components/DrilldownPanel/NodePane.vue
@@ -93,8 +93,8 @@
     getNeighbours (): void {
       eventHub.$emit('get-bgraph', bgraph => {
         if (bgraph) {
-          this.outgoingNodes = bgraph.v({ id: this.data.id }).out().out().run();
-          this.incomingNodes = bgraph.v({ id: this.data.id }).in().in().run();
+          this.outgoingNodes = bgraph.v({ id: this.data.id }).out().out().unique().run();
+          this.incomingNodes = bgraph.v({ id: this.data.id }).in().in().unique().run();
         }
       });
     }

--- a/client/src/views/Graphs/components/DrilldownPanel/NodePane.vue
+++ b/client/src/views/Graphs/components/DrilldownPanel/NodePane.vue
@@ -75,10 +75,9 @@
     isLoading = false;
     displayAllIncoming = false;
     displayAllOutgoing = false;
+    incomingNodes: string[] = [];
+    outgoingNodes: string[] = [];
     emmaaInfo: EmmaaEntityInfoInterface = emptyEmmaaInfo;
-    // incomingNodes and outgoingNodes MUST NOT be initialised to disable reactivity
-    incomingNodes: any[];
-    outgoingNodes: any[];
 
     @Watch('data') onDataChange (): void {
       this.fetchExternalData();
@@ -93,8 +92,20 @@
     getNeighbours (): void {
       eventHub.$emit('get-bgraph', bgraph => {
         if (bgraph) {
-          this.outgoingNodes = bgraph.v({ id: this.data.id }).out().out().unique().run();
-          this.incomingNodes = bgraph.v({ id: this.data.id }).in().in().unique().run();
+          this.outgoingNodes = bgraph
+            .v({ id: this.data.id })
+            .out()
+            .out()
+            .unique()
+            .run()
+            .map(node => `${node.vertex.name} → ${this.data.label}`);
+          this.incomingNodes = bgraph
+            .v({ id: this.data.id })
+            .in()
+            .in()
+            .unique()
+            .run()
+            .map(node => `${this.data.label} → ${node.vertex.name}`);
         }
       });
     }
@@ -111,17 +122,15 @@
     }
 
     get incoming (): string[] {
-      const incomingMap = this.incomingNodes.map(node => `${node.vertex.name} → ${this.data.label}`);
       return this.displayAllIncoming
-        ? incomingMap
-        : incomingMap.slice(0, 5);
+        ? this.incomingNodes
+        : this.incomingNodes.slice(0, 5);
     }
 
     get outgoing (): string[] {
-      const outgoingMap = this.outgoingNodes.map(node => `${this.data.label} → ${node.vertex.name}`);
       return this.displayAllOutgoing
-        ? outgoingMap
-        : outgoingMap.slice(0, 5);
+        ? this.outgoingNodes
+        : this.outgoingNodes.slice(0, 5);
     }
 
     viewAllIncoming (): void {


### PR DESCRIPTION
Add in and out neighbour lists to the bio subgraph populated using bgraph for the currently selected node. Test by selecting different nodes in the bio subgraph.

Fixes #251

https://user-images.githubusercontent.com/14062458/125315658-55dfbd00-e305-11eb-8b17-b1e1bb00c8bb.mov

Notes: This PR changes how collapsible container and collapsible item works, by changing the CSS that fits these two components to the parent container. It is likely that this change will break existing components that use these two components. From a quick search, that appears to be only the edge panel which is currently disabled. I think we should just keep this in mind, keep an eye on it, and fix any potential problems when they appear. It will be good to double check that there are no other actively used components incorporating collapsible components though.