### PR TITLE
Make sure only GroMET models from Donu API are used on the HMI

### DIFF
--- a/client/src/services/DonuService.ts
+++ b/client/src/services/DonuService.ts
@@ -21,7 +21,10 @@ export const fetchDonuModels = async (): Promise<any[]> => {
   const response = await callDonu(request);
   if (response.status === Donu.ResponseStatus.success) {
     const models = response?.result as Donu.ModelDefinition[] ?? null;
-    return donuToModel(models);
+    const grometOnlyModels = models.filter(model => {
+      return [Donu.Type.GROMET_PNC, Donu.Type.GROMET_PRT].includes(model.type);
+    });
+    return donuToModel(grometOnlyModels);
   } else {
     console.error('[DONU Service] — fetchDonuModels', response); // eslint-disable-line no-console
   }

--- a/client/src/services/DonuService.ts
+++ b/client/src/services/DonuService.ts
@@ -22,7 +22,7 @@ export const fetchDonuModels = async (): Promise<any[]> => {
   if (response.status === Donu.ResponseStatus.success) {
     const models = response?.result as Donu.ModelDefinition[] ?? null;
     const grometOnlyModels = models.filter(model => {
-      return [Donu.Type.GROMET_PNC, Donu.Type.GROMET_PRT].includes(model.type);
+      return [Donu.Type.GROMET_PNC/*, Donu.Type.GROMET_FN */].includes(model.type);
     });
     return donuToModel(grometOnlyModels);
   } else {

--- a/client/src/static/mockedDataDemo.ts
+++ b/client/src/static/mockedDataDemo.ts
@@ -42,7 +42,7 @@ export const buildInitialModelsList = ({ SIR_PN, SIR_FN, SEIR_PN, SEIRD_PN, SIRD
           },
         },
         {
-          donuType: Donu.Type.EASEL,
+          donuType: Donu.Type.GROMET_PRT,
           model: 'sir.easel',
           type: Model.GraphTypes.FunctionNetwork,
           metadata: SIR_FN.metadata,

--- a/client/src/store/modules/model.ts
+++ b/client/src/store/modules/model.ts
@@ -17,7 +17,7 @@ const actions: ActionTree<Model.State, any> = {
     // filter out non-gromets
     const modelList = initialModelsList.map(model => {
       model.modelGraph = model.modelGraph.filter(graph => {
-        return [Donu.Type.GROMET_PNC, Donu.Type.GROMET_PRT].includes(graph.donuType);
+        return [Donu.Type.GROMET_PNC/*, Donu.Type.GROMET_FN */].includes(graph.donuType);
       });
       if (model.modelGraph.length > 0) return model;
     });

--- a/client/src/store/modules/model.ts
+++ b/client/src/store/modules/model.ts
@@ -1,4 +1,5 @@
 import { GetterTree, MutationTree, ActionTree } from 'vuex';
+import * as Donu from '@/types/typesDonu';
 import * as Model from '@/types/typesModel';
 import { fetchInitialModelData } from '@/static/mockedDataDemo';
 
@@ -12,7 +13,16 @@ const state: Model.State = {
 const actions: ActionTree<Model.State, any> = {
   async setInitialModelsState ({ commit }) {
     const initialModelsList = await fetchInitialModelData();
-    commit('setModelsList', initialModelsList);
+
+    // filter out non-gromets
+    const modelList = initialModelsList.map(model => {
+      model.modelGraph = model.modelGraph.filter(graph => {
+        return [Donu.Type.GROMET_PNC, Donu.Type.GROMET_PRT].includes(graph.donuType);
+      });
+      if (model.modelGraph.length > 0) return model;
+    });
+
+    commit('setModelsList', modelList);
     commit('setIsInitialized', true);
   },
 };

--- a/client/src/types/typesDonu.ts
+++ b/client/src/types/typesDonu.ts
@@ -15,11 +15,11 @@ enum RequestCommand {
 }
 
 enum Type {
-  // CORE = 'core',
-  // DIFF_EQS = 'diff-eqs',
+  CORE = 'core',
+  DIFF_EQS = 'diff-eqs',
   EASEL = 'easel',
   GROMET_PNC = 'gromet-pnc',
-  // GROMET_PRT = 'gromet-prt',
+  GROMET_PRT = 'gromet-prt',
 }
 
 type Metadata = {


### PR DESCRIPTION
**What**
- filter out the non-GroMET models from the Donu APOI and the mocked data.

**How**
- use the current [Donu `model-def`](https://galoisinc.github.io/ASKE-E/donu.html#model-def) and only use `gromet-pnc` and `gromet-prt`.