### PR TITLE
Visual refinements in the Simulation space

### DIFF
--- a/client/src/styles/overrides.css
+++ b/client/src/styles/overrides.css
@@ -27,8 +27,10 @@
 
 .btn-primary.btn-primary,
 .btn-primary.btn-primary:focus,
+.btn-primary.btn-primary.active,
 .btn-primary.btn-primary:active,
-.btn-primary.btn-primary.active {
+.btn-primary.btn-primary:not(:disabled):not(.disabled).active,
+.btn-primary.btn-primary:not(:disabled):not(.disabled):active {
   background-color: var(--nord4);
   border-color: var(--nord4);
   box-shadow: none;

--- a/client/src/views/Simulation/Simulation.vue
+++ b/client/src/views/Simulation/Simulation.vue
@@ -1,39 +1,55 @@
 <template>
   <div class="view-container">
-    <div class="search-row">
-      <div class="search-col flex-column">
-        <search-bar />
-      </div>
-      <div class="search-col mx-3 justify-content-between">
-        <button class="btn btn-primary blue m-1">
-          Simulate
-        </button>
-        <button class="btn btn-primary m-1">
-          <font-awesome-icon :icon="['fas', 'project-diagram' ]" />
-          <span>Provenance Graph </span>
-        </button>
-      </div>
-      <div class="search-col justify-content-end">
+    <header>
+      <button
+        class="btn btn-primary"
+        :class="{ 'active': displaySearch }"
+        @click="displaySearch = !displaySearch"
+      >
+        <font-awesome-icon :icon="['fas', 'search' ]" />
+        <span>Search</span>
+      </button>
+
+      <button class="btn btn-primary">
+        <font-awesome-icon :icon="['fas', 'project-diagram' ]" />
+        <span>Provenance Graph</span>
+      </button>
+
+      <div class="runs-controls">
         <run-button
-          class="m-1"
           :auto-run.sync="autoRun"
           :config.sync="runConfig"
           @run="fetchResults"
         />
-        <div class="btn-group m-1">
-          <button class="btn btn-primary" title="Save current run" @click="incrNumberOfSavedRuns">
+
+        <div class="btn-group">
+          <button
+            class="btn btn-primary"
+            title="Save current run"
+            @click="incrNumberOfSavedRuns"
+          >
             <font-awesome-icon :icon="['fas', 'bookmark' ]" />
           </button>
-          <button class="btn btn-primary" title="Reset all saved runs" @click="onResetSim">
+          <button
+            class="btn btn-primary"
+            title="Reset all saved runs"
+            @click="onResetSim"
+          >
             <font-awesome-icon :icon="['fas', 'undo' ]" />
           </button>
         </div>
-        <button class="btn btn-primary m-1" @click="onCloseSimView">
-          <font-awesome-icon :icon="['fas', 'sign-out-alt' ]" />
-          <span> Close Simulation </span>
-        </button>
       </div>
-    </div>
+
+      <button class="btn btn-primary" @click="onCloseSimView">
+        <font-awesome-icon :icon="['fas', 'sign-out-alt' ]" />
+        <span> Close Simulation </span>
+      </button>
+    </header>
+
+    <aside class="search-bar" :class="{ 'active': displaySearch }">
+      <search-bar />
+    </aside>
+
     <resizable-grid :map="gridMap" :dimensions="gridDimensions">
       <model-panel
         class="simulation-panel"
@@ -92,9 +108,10 @@
   @Component({ components })
   export default class Simulation extends Vue {
     autoRun: boolean = false;
+    displaySearch: boolean = false;
+    expandedId: string = '';
     runConfig: Donu.RequestConfig = { end: 120, start: 0, step: 30 };
     subgraph: Graph.GraphInterface = null;
-    expandedId: string = '';
 
     @Action fetchModelResults;
     @Action incrNumberOfSavedRuns;
@@ -213,6 +230,35 @@
     flex-grow: 1;
   }
 
+  header {
+    align-items: center;
+    background-color: var(--bg-secondary);
+    display: flex;
+    flex-direction: row;
+    gap: 2em;
+    justify-content: space-between;
+    padding: 10px 5px;
+  }
+
+  .search-bar {
+    background-color: var(--bg-secondary);
+    max-height: 0;
+    overflow: hidden;
+    pointer-events: none; /* Avoid potential clicks to happen */
+    transition: max-height 250ms ease-in-out;
+    will-change: max-height;
+  }
+
+  .search-bar.active {
+    max-height: 10rem; /* Random number bigger than actual height for the transition. */
+    pointer-events: auto;
+  }
+
+  .search-bar.settings-bar-container {
+    margin-top: 0; /* To have an uniform spacing between the header and the search bar */
+    margin-bottom: 10px; /* To match the header vertical spacing */
+  }
+
   /* Uniform sizing of the panels */
   .simulation-panel {
     display: flex;
@@ -234,16 +280,7 @@
     border-color: var(--muted-highlight);
   }
 
-  .search-col {
-    display: flex;
-    flex: 1;
-  }
-
   .left-side-panel {
     flex-shrink: 0;
-  }
-
-  .form-check-label {
-    color: var(--text-color-light);
   }
 </style>

--- a/client/src/views/Simulation/components/ModelPanel.vue
+++ b/client/src/views/Simulation/components/ModelPanel.vue
@@ -3,28 +3,6 @@
     <settings-bar>
       <counters slot="left" :title="modelName" :data="countersData" />
       <aside slot="right">
-        <div class="dropdown">
-          <button
-            class="btn btn-secondary dropdown-toggle"
-            type="button"
-            @click="settingsOpen = !settingsOpen">
-            Settings
-          </button>
-          <div class="dropdown-menu dropdown-menu-right" :class="{ 'show': settingsOpen }">
-            <h6 class="dropdown-header">Model view</h6>
-            <div v-for="(view, index) in views" :key="index" class="custom-control custom-radio">
-              <input
-                class="custom-control-input"
-                name="model-view"
-                type="radio"
-                v-model="selectedView"
-                :id="('model-view-'+index)"
-                :value="view.id"
-              >
-              <label class="custom-control-label" :for="('model-view-'+index)">{{ view.name }}</label>
-            </div>
-          </div>
-        </div>
         <button
           class="btn btn-secondary"
           title="Expand Model Panel"
@@ -44,7 +22,6 @@
   import Component from 'vue-class-component';
   import { Prop } from 'vue-property-decorator';
   import { Getter } from 'vuex-class';
-  import { capitalize } from 'lodash';
   import * as HMI from '@/types/types';
   import * as Model from '@/types/typesModel';
   import * as Graph from '@/types/typesGraphs';
@@ -60,12 +37,6 @@
     ModelSelector,
   };
 
-  // List of available graphs in a model
-  enum VIEWS {
-    CAUSAL = 'causal',
-    FUNCTIONAL = 'functional',
-  }
-
   @Component({ components })
   export default class ModelPanel extends Vue {
     @Prop({ default: false }) expanded: boolean;
@@ -74,12 +45,7 @@
     @Getter getSimParameters;
     @Getter getSimVariables;
 
-    selectedView: string = VIEWS.CAUSAL;
     settingsOpen: boolean = false;
-    views: HMI.ViewInterface[] = [
-      { name: capitalize(VIEWS.CAUSAL), id: VIEWS.CAUSAL },
-      { name: capitalize(VIEWS.FUNCTIONAL), id: VIEWS.FUNCTIONAL },
-    ];
 
     get graph (): Graph.GraphInterface {
       return this.model?.modelGraph?.[0]?.graph;

--- a/client/src/views/Simulation/components/ParametersPanel.vue
+++ b/client/src/views/Simulation/components/ParametersPanel.vue
@@ -7,37 +7,30 @@
     }"
   >
     <settings-bar>
-      <div class="btn-group" slot="left" aria-label="Show/Hide Parameters">
-        <button
-          class="btn btn-secondary"
-          title="Show all parameters"
-          type="button"
-          @click="onShowAllParameters"
-        >
-          <font-awesome-icon :icon="['fas', 'eye']" />
-        </button>
-        <button
-          class="btn btn-secondary"
-          title="Hide all parameters"
-          type="button"
-          @click="onHideAllParameters"
-        >
-          <font-awesome-icon :icon="['fas', 'eye-slash']" />
-        </button>
-      </div>
       <counters
-        slot="middle"
+        slot="left"
         :title="countersTitle"
         :data="countersData"
       />
-      <div slot="right">
-        <button
-          class="btn btn-secondary"
-          disabled
-          type="button"
-          @click="$emit('settings')">
-          Settings
-        </button>
+      <aside slot="right">
+        <div class="btn-group" title="Show/Hide Parameters">
+          <button
+            class="btn btn-secondary"
+            title="Show all parameters"
+            type="button"
+            @click="onShowAllParameters"
+          >
+            <font-awesome-icon :icon="['fas', 'eye']" />
+          </button>
+          <button
+            class="btn btn-secondary"
+            title="Hide all parameters"
+            type="button"
+            @click="onHideAllParameters"
+          >
+            <font-awesome-icon :icon="['fas', 'eye-slash']" />
+          </button>
+        </div>
         <button
           class="btn btn-secondary"
           title="Expand Parameters Panel"
@@ -45,7 +38,7 @@
           @click="$emit('expand')">
           <font-awesome-icon :icon="['fas', (expanded ? 'compress-alt' : 'expand-alt')]" />
         </button>
-      </div>
+      </aside>
     </settings-bar>
     <div class="parameters">
       <figure class="parameters-graph" ref="figure"><svg /></figure>

--- a/client/src/views/Simulation/components/RunButton.vue
+++ b/client/src/views/Simulation/components/RunButton.vue
@@ -49,7 +49,7 @@
     dropdownOpen: boolean = false;
 
     get displayText (): string {
-      return this.autoRunInput ? 'Auto-Run' : 'Run';
+      return this.autoRunInput ? 'Auto' : 'Run ';
     }
 
     /* On auto-run, remove the auto-run feature, otherwise, run the simulation. */
@@ -64,6 +64,10 @@
 </script>
 
 <style scoped>
+  button:first-of-type {
+    width: 5em;
+  }
+
   .dropdown-menu {
     padding: 1em;
   }
@@ -75,6 +79,7 @@
   /* Make the caret bigger */
   .dropdown-toggle {
     font-size: 1.5em;
+    padding: 0 .5625rem; /* Bootstap thingy */
   }
 
   /* Reverse the caret when open */

--- a/client/src/views/Simulation/components/VariablesPanel.vue
+++ b/client/src/views/Simulation/components/VariablesPanel.vue
@@ -7,15 +7,10 @@
         :data="countersData"
       />
       <div class="d-flex align-items-center" slot="right">
-        <small class="mr-3 run-counter" v-if="getVariablesRunsCount">
-          {{`${getVariablesRunsCount} run${getVariablesRunsCount > 1 ? 's' : ''}`}}
-        </small>
-        <div>
-          <button type="button" disabled class="btn btn-secondary btn-settings">Settings</button>
-          <button type="button" class="btn btn-secondary py-0 btn-settings" @click="$emit('expand')">
-            <font-awesome-icon :icon="['fas', (expanded ? 'compress-alt' : 'expand-alt')]" />
-          </button>
-        </div>
+        <span class="run-counter" v-if="getVariablesRunsCount">{{ runCounter }}</span>
+        <button type="button" class="btn btn-secondary py-0 btn-settings" @click="$emit('expand')">
+          <font-awesome-icon :icon="['fas', (expanded ? 'compress-alt' : 'expand-alt')]" />
+        </button>
       </div>
     </settings-bar>
 
@@ -162,6 +157,11 @@
         }
       } else return [];
     }
+
+    get runCounter (): string {
+      const count = this.getVariablesRunsCount;
+      return `${count} run${count > 1 ? 's' : ''}`;
+    }
   }
 </script>
 
@@ -186,6 +186,8 @@
 
   .run-counter {
     color: var(--text-color-light);
+    font-size: .8em;
+    margin-right: 1rem;
   }
 
   .chart {


### PR DESCRIPTION
**What**
- Fix #256
- Other random UI changes to tidy up things

**How**
- Remove _Simulate_ button
- Remove all the _Settings_ buttons on the panels, are they have no uses
- Made the header control bar tidy with smaller buttons, better spacing
- Move the search bar to its own element that is made visible via the _Search_ toggle in the header
- Made the _Run_ fixed in width to avoid visual jump between _Run_ and _Auto_ labels
- Move the _Show/Hide all parameters_  buttons to the right of the panel to display the counter on the left like in the other panels.

**Video**

https://user-images.githubusercontent.com/636801/125829552-1bf89588-e343-4529-86fc-791fb3dcec10.mov