### PR TITLE
Added double click on model representation panel to hide/show parameters and variables in simulation view

### DIFF
--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -202,7 +202,9 @@ export default class EpiRenderer extends SVGRenderer {
 
     chart.selectAll('.node-ui').each(function (d) {
       const isHighlighted = nodes.map(node => node.id).includes(d.id);
-      d3.select(this).select('rect').style('fill', isHighlighted ? Colors.NODES.VARIABLE : EpiRenderer.calcNodeColor(d));
+      d3.select(this).select('rect')
+        .style('stroke', isHighlighted ? Colors.HIGHLIGHT : Colors.STROKE)
+        .style('stroke-width', DEFAULT_STYLE.node.strokeWidth + (isHighlighted ? 3 : 0));
     });
   }
 

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -185,7 +185,7 @@ export default class EpiRenderer extends SVGRenderer {
       d3.select(this).style('opacity', isNeighbour ? '1' : '0.1');
     });
     chart.selectAll('.node-ui').each(function (d) {
-      const isNeighbour = nodes.map(node => node.id).includes(d.id);
+      const isNeighbour = nodes.map(node => node).includes(d.id);
       d3.select(this).style('opacity', isNeighbour ? '1' : '0.1');
     });
   }
@@ -194,6 +194,16 @@ export default class EpiRenderer extends SVGRenderer {
     node.select('rect')
       .style('stroke', Colors.HIGHLIGHT)
       .style('stroke-width', DEFAULT_STYLE.node.strokeWidth + 3);
+  }
+
+  highlightSubgraph (subgraph: SubgraphInterface): void {
+    const chart = (this as any).chart;
+    const nodes = subgraph.nodes;
+
+    chart.selectAll('.node-ui').each(function (d) {
+      const isHighlighted = nodes.map(node => node.id).includes(d.id);
+      d3.select(this).select('rect').style('fill', isHighlighted ? Colors.NODES.VARIABLE : EpiRenderer.calcNodeColor(d));
+    });
   }
 
   clearSelections ():void {

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -31,6 +31,14 @@ export default class EpiRenderer extends SVGRenderer {
     super(options);
   }
 
+  static calcNodeColor (d: d3.Selection<any, any, any, any>): string {
+    if ((d as any).nodes) {
+      return Colors.NODES.CONTAINER;
+    } else {
+      return (d as any).data.role?.includes(NodeTypes.NODES.VARIABLE) ? Colors.NODES.VARIABLE : DEFAULT_STYLE.node.fill;
+    }
+  }
+
   buildDefs (): void {
     const svg = d3.select((this as any).svgEl);
     const edges = flatten((this as any).layout).edges;
@@ -105,13 +113,7 @@ export default class EpiRenderer extends SVGRenderer {
         .attr('rx', DEFAULT_STYLE.node.borderRadius)
         .attr('width', d => (d as any).width)
         .attr('height', d => (d as any).height)
-        .style('fill', d => {
-          if ((d as any).nodes) {
-            return Colors.NODES.CONTAINER;
-          } else {
-            return (d as any).data.role?.includes(NodeTypes.NODES.VARIABLE) ? Colors.NODES.VARIABLE : DEFAULT_STYLE.node.fill;
-          }
-        })
+        .style('fill', EpiRenderer.calcNodeColor)
         .style('stroke', DEFAULT_STYLE.node.stroke)
         .style('stroke-width', DEFAULT_STYLE.node.strokeWidth);
 
@@ -192,6 +194,16 @@ export default class EpiRenderer extends SVGRenderer {
     node.select('rect')
       .style('stroke', Colors.HIGHLIGHT)
       .style('stroke-width', DEFAULT_STYLE.node.strokeWidth + 3);
+  }
+
+  highlightSubgraph (subgraph: SubgraphInterface): void {
+    const chart = (this as any).chart;
+    const nodes = subgraph.nodes;
+
+    chart.selectAll('.node-ui').each(function (d) {
+      const isHighlighted = nodes.map(node => node.id).includes(d.id);
+      d3.select(this).select('rect').style('fill', isHighlighted ? Colors.NODES.VARIABLE : EpiRenderer.calcNodeColor(d));
+    });
   }
 
   clearSelections ():void {

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -185,7 +185,7 @@ export default class EpiRenderer extends SVGRenderer {
       d3.select(this).style('opacity', isNeighbour ? '1' : '0.1');
     });
     chart.selectAll('.node-ui').each(function (d) {
-      const isNeighbour = nodes.map(node => node).includes(d.id);
+      const isNeighbour = nodes.map(node => node.id).includes(d.id);
       d3.select(this).style('opacity', isNeighbour ? '1' : '0.1');
     });
   }
@@ -194,16 +194,6 @@ export default class EpiRenderer extends SVGRenderer {
     node.select('rect')
       .style('stroke', Colors.HIGHLIGHT)
       .style('stroke-width', DEFAULT_STYLE.node.strokeWidth + 3);
-  }
-
-  highlightSubgraph (subgraph: SubgraphInterface): void {
-    const chart = (this as any).chart;
-    const nodes = subgraph.nodes;
-
-    chart.selectAll('.node-ui').each(function (d) {
-      const isHighlighted = nodes.map(node => node.id).includes(d.id);
-      d3.select(this).select('rect').style('fill', isHighlighted ? Colors.NODES.VARIABLE : EpiRenderer.calcNodeColor(d));
-    });
   }
 
   clearSelections ():void {

--- a/client/src/views/Models/components/Graphs/GlobalGraph.vue
+++ b/client/src/views/Models/components/Graphs/GlobalGraph.vue
@@ -118,9 +118,11 @@
       });
 
       this.renderer.setCallback('backgroundClick', () => {
-        this.renderer.hideSubgraph();
-        this.renderer.clearSelections();
-        this.$emit('background-click');
+        if (!this.highlighted) {
+          this.renderer.hideSubgraph();
+          this.renderer.clearSelections();
+          this.$emit('background-click');
+        }
       });
 
       this.refresh();

--- a/client/src/views/Models/components/Graphs/GlobalGraph.vue
+++ b/client/src/views/Models/components/Graphs/GlobalGraph.vue
@@ -30,6 +30,7 @@
   export default class GlobalGraph extends Vue {
     @Prop({ default: null }) data: GraphInterface;
     @Prop({ default: null }) subgraph: SubgraphInterface;
+    @Prop({ default: null }) highlighted: SubgraphInterface;
     @Prop({ default: GraphLayoutInterfaceType.elk }) layout: string;
 
     renderingOptions = DEFAULT_RENDERING_OPTIONS;
@@ -38,6 +39,7 @@
     @Watch('data')
     dataChanged (): void {
       this.refresh();
+      this.renderer.highlightSubgraph(this.highlighted);
     }
 
     @Watch('subgraph')
@@ -49,6 +51,12 @@
     async layoutChanged (): Promise<void> {
       await this.refresh();
       this.subgraphChanged();
+      this.renderer.highlightSubgraph(this.highlighted);
+    }
+
+    @Watch('highlighted')
+    async highlightedChanged (): Promise<void> {
+      this.renderer.highlightSubgraph(this.highlighted);
     }
 
     subgraphChanged (): void {
@@ -70,6 +78,10 @@
         addons: [expandCollapse, highlight],
       });
 
+      this.renderer.setCallback('nodeDblClick', (evt, node) => {
+          this.$emit('node-dblclick', node.datum().data);
+      });
+
       this.renderer.setCallback('nodeClick', (evt, node) => {
         this.renderer.hideSubgraph();
 
@@ -77,6 +89,8 @@
           const id = node.datum().id;
           if (node.datum().collapsed === true) {
             this.renderer.expand(id);
+            // Wait for renderer.expand to finish async updates before calling highlightSubgraph
+            setTimeout(() => this.renderer.highlightSubgraph(this.highlighted), 500);
           } else {
             this.renderer.collapse(id);
           }

--- a/client/src/views/Simulation/components/ModelPanel.vue
+++ b/client/src/views/Simulation/components/ModelPanel.vue
@@ -12,7 +12,7 @@
         </button>
       </aside>
     </settings-bar>
-    <global-graph v-if="model" :data="graph" :subgraph="highlighted" @node-dblclick="onNodeClick"/>
+    <global-graph v-if="model" :data="graph" :highlighted="highlighted" @node-dblclick="onNodeClick"/>
   </section>
 </template>
 
@@ -65,7 +65,7 @@
       ];
       return {
         nodes: this.graph.nodes.filter(node => highlightedLabels.includes(node.label)),
-        edges: this.graph.edges,
+        edges: [],
       };
     }
 

--- a/client/src/views/Simulation/components/ModelPanel.vue
+++ b/client/src/views/Simulation/components/ModelPanel.vue
@@ -12,7 +12,7 @@
         </button>
       </aside>
     </settings-bar>
-    <global-graph v-if="model" :data="graph" :highlighted="highlighted" @node-dblclick="onNodeClick"/>
+    <global-graph v-if="model" :data="graph" :subgraph="highlighted" @node-dblclick="onNodeClick"/>
   </section>
 </template>
 
@@ -65,7 +65,7 @@
       ];
       return {
         nodes: this.graph.nodes.filter(node => highlightedLabels.includes(node.label)),
-        edges: [],
+        edges: this.graph.edges,
       };
     }
 

--- a/client/src/views/Simulation/components/ModelPanel.vue
+++ b/client/src/views/Simulation/components/ModelPanel.vue
@@ -12,8 +12,7 @@
         </button>
       </aside>
     </settings-bar>
-    <model-selector/>
-    <global-graph v-if="model" :data="graph"/>
+    <global-graph v-if="model" :data="graph" :highlighted="highlighted" @node-dblclick="onNodeClick"/>
   </section>
 </template>
 
@@ -28,13 +27,11 @@
   import Counters from '@/components/Counters.vue';
   import SettingsBar from '@/components/SettingsBar.vue';
   import GlobalGraph from '@/views/Models/components/Graphs/GlobalGraph.vue';
-  import ModelSelector from '@/views/Simulation/components/ModelSelector.vue';
 
   const components = {
     Counters,
     GlobalGraph,
     SettingsBar,
-    ModelSelector,
   };
 
   @Component({ components })
@@ -46,6 +43,31 @@
     @Getter getSimVariables;
 
     settingsOpen: boolean = false;
+
+    onNodeClick (selected: Graph.GraphNodeInterface): void {
+      const selectedName = selected.label;
+      this.getSimParameters.forEach(parameter => {
+        if (parameter.metadata.name === selectedName) {
+          parameter.hidden = !parameter.hidden;
+        }
+      });
+      this.getSimVariables.forEach(variable => {
+        if (variable.metadata.name === selectedName) {
+          variable.hidden = !variable.hidden;
+        }
+      });
+    }
+
+    get highlighted (): Graph.GraphInterface {
+      const highlightedLabels = [
+        ...this.getSimParameters.filter(parameter => !parameter.hidden).map(parameter => parameter.metadata.name),
+        ...this.getSimVariables.filter(variable => !variable.hidden).map(variable => variable.metadata.name),
+      ];
+      return {
+        nodes: this.graph.nodes.filter(node => highlightedLabels.includes(node.label)),
+        edges: [],
+      };
+    }
 
     get graph (): Graph.GraphInterface {
       return this.model?.modelGraph?.[0]?.graph;


### PR DESCRIPTION
Double click nodes in the model representation panel to hide or show parameters and variables in the other panels. Solves #245

Check if PR #268 would impact this PR

Note: There is a limitation that when a node is toggled, then all parameters and variables with the label of the toggled node are toggled, which could be problematic if there is multiple parameters and variables with the same label.

https://user-images.githubusercontent.com/14062458/125829162-98332b76-c023-41a8-9bed-32f452445ccb.mov

