### PR TITLE
Donu fixes for PNC GroMET execution

### DIFF
--- a/client/src/store/modules/simulation.ts
+++ b/client/src/store/modules/simulation.ts
@@ -34,7 +34,7 @@ const getters: GetterTree<any, HMI.SimulationParameter[]> = {
     const output = new Array(RunsCount);
     for (let i = 0; i < RunsCount; i++) {
       output[i] = state.parameters.reduce((obj, parameter) => {
-        obj[parameter.metadata.name] = parameter.values[i];
+        obj[parameter.uid] = parameter.values[i];
         return obj;
       }, {});
     }
@@ -56,7 +56,7 @@ const actions: ActionTree<SimulationState, HMI.SimulationParameter[]> = {
     commit('setNumberOfSavedRuns', args.count ?? currentNumberOfRuns(state));
   },
 
-  setSimParameterValue ({ state, commit }, args: { name: string, value: number }): void {
+  setSimParameterValue ({ state, commit }, args: { uid: string, value: number }): void {
     let parameters = [] as HMI.SimulationParameter[];
 
     if (currentNumberOfRuns(state) < state.numberOfSavedRuns) {
@@ -67,7 +67,7 @@ const actions: ActionTree<SimulationState, HMI.SimulationParameter[]> = {
       });
     } else {
       parameters = state.parameters.map(parameter => {
-        if (parameter.metadata.name === args.name) {
+        if (parameter.uid === args.uid) {
           parameter.values[parameter.values.length - 1] = args.value;
         }
         return parameter;

--- a/client/src/views/Simulation/components/ParametersPanel.vue
+++ b/client/src/views/Simulation/components/ParametersPanel.vue
@@ -57,7 +57,7 @@
           :class="{ hidden: parameter.hidden }"
         >
           <h4 :title="parameter.metadata.Description">{{ parameter.metadata.name }}</h4>
-          <input type="text" :value="getCurrentValue(parameter)" @change="e => onParameterChange(parameter.metadata.name, e)" />
+          <input type="text" :value="getCurrentValue(parameter)" @change="e => onParameterChange(parameter.uid, e)" />
           <aside class="btn-group">
             <button type="button" class="btn btn-secondary btn-sm">
               <font-awesome-icon :icon="['fas', 'tools']" />
@@ -147,9 +147,9 @@
       return figure?.getBoundingClientRect().width ?? 0;
     }
 
-    onParameterChange (name: string, event: Event): void {
+    onParameterChange (uid: string, event: Event): void {
       const value = Number((event.target as HTMLInputElement).value);
-      this.setSimParameterValue({ name, value });
+      this.setSimParameterValue({ uid, value });
     }
 
     clearGraph (): void {

--- a/client/src/views/Simulation/components/ParametersPanel.vue
+++ b/client/src/views/Simulation/components/ParametersPanel.vue
@@ -118,7 +118,7 @@
 
     get parameters (): HMI.SimulationParameter[] {
       // Order by ASC order
-      return _.orderBy(this.getSimParameters, ['name'], ['asc']);
+      return _.orderBy(this.getSimParameters, ['metadata.name'], ['asc']);
     }
 
     get countersTitle (): string {
@@ -157,8 +157,8 @@
     }
 
     drawGraph (): void {
-      // List of parameters names
-      const params = this.parameters.map(parameter => parameter.metadata.name);
+      // List of parameters uid
+      const params = this.parameters.map(parameter => parameter.uid);
 
       // List of runs
       const runs = this.getSimParameterArray;


### PR DESCRIPTION
**What**
GroMET PNC Donu API simulations were sending identical results.

**How**
By targeting the parameter `uid` instead of its `metadata.name` to send requests.
[This change was not documented](https://galoisinc.github.io/ASKE-E/donu.html#simulate---simulate-a-model), so thanks to @liunelson for reaching out to Galois.

**Screenshot**

![Screen Shot 2021-07-15 at 16 08 48](https://user-images.githubusercontent.com/636801/125851219-17ecbc1b-dddb-4bf9-abda-67b92b750d4e.png)
