### PR TITLE
Display the search bar on the model like on the simulation view.

### DIFF
--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -12,59 +12,98 @@
         :metadata="selectedGraphMetadata"
       />
     </left-side-panel>
-    <div class="d-flex flex-column flex-grow-1 position-relative">
-      <div class="search-row">
-        <search-bar :placeholder="`Search for model components...`"/>
-        <button class="btn btn-primary m-1" @click="onOpenSimView">
-          <font-awesome-icon :icon="['fas', 'chart-line' ]" />
-          <span> Open Simulation View </span>
+
+    <section>
+      <header>
+        <button
+          class="btn btn-primary"
+          :class="{ 'active': displaySearch }"
+          @click="displaySearch = !displaySearch"
+        >
+          <font-awesome-icon :icon="['fas', 'search' ]" />
+          Search
         </button>
-      </div>
-      <div class="d-flex flex-column h-100 w-100">
-        <settings-bar>
-          <counters
-            slot="left"
-            :title="selectedModel && selectedModel.name"
-            :data="[
-              { name: 'Nodes', value: nodeCount },
-              { name: 'Edges', value: edgeCount },
-            ]"
-          />
-          <settings
-            slot="right"
-            :selected-view-id="selectedViewId"
-            :views="views"
-            :layouts="layouts"
-            :selected-layout-id="selectedLayoutId"
-            @view-change="onSetView"
-            @layout-change="onSetLayout"
-          />
-        </settings-bar>
-        <global-graph
-          v-if="selectedGraph"
-          :data="selectedGraph"
-          :subgraph="subgraph"
-          :layout="selectedLayoutId"
-          @node-click="onNodeClick"
-          @background-click="onBackgroundClick"
+        <button
+          class="btn-sim btn btn-primary"
+          @click="onOpenSimView"
+        >
+          <font-awesome-icon :icon="['fas', 'chart-line' ]" />
+          Open Simulation
+        </button>
+      </header>
+
+      <aside class="search-bar" :class="{ 'active': displaySearch }">
+        <search-bar :placeholder="`Search for model components...`"/>
+      </aside>
+
+      <settings-bar>
+        <counters
+          slot="left"
+          :title="selectedModel && selectedModel.name"
+          :data="[
+            { name: 'Nodes', value: nodeCount },
+            { name: 'Edges', value: edgeCount },
+          ]"
         />
-      </div>
-    </div>
-    <drilldown-panel @close-pane="onCloseDrilldownPanel" :tabs="drilldownTabs" :active-tab-id="drilldownActiveTabId" :is-open="isOpenDrilldown" :pane-title="drilldownPaneTitle" :pane-subtitle="drilldownPaneSubtitle" @tab-click="onDrilldownTabClick">
-      <metadata-pane v-if="drilldownActiveTabId === 'metadata'" slot="content" :data="drilldownMetadata" @open-modal="onOpenModalMetadata"/>
-      <parameters-pane v-if="drilldownActiveTabId === 'parameters'" slot="content" :data="drilldownParameters" :related="drilldownRelatedParameters" @open-modal="onOpenModalParameters"/>
-      <knowledge-pane v-if="drilldownActiveTabId === 'knowledge'" slot="content" :data="drilldownKnowledge"/>
+        <settings
+          slot="right"
+          :selected-view-id="selectedViewId"
+          :views="views"
+          :layouts="layouts"
+          :selected-layout-id="selectedLayoutId"
+          @view-change="onSetView"
+          @layout-change="onSetLayout"
+        />
+      </settings-bar>
+
+      <global-graph
+        v-if="selectedGraph"
+        :data="selectedGraph"
+        :subgraph="subgraph"
+        :layout="selectedLayoutId"
+        @node-click="onNodeClick"
+        @background-click="onBackgroundClick"
+      />
+    </section>
+
+    <drilldown-panel
+      :active-tab-id="drilldownActiveTabId"
+      :is-open="isOpenDrilldown"
+      :pane-subtitle="drilldownPaneSubtitle"
+      :pane-title="drilldownPaneTitle"
+      :tabs="drilldownTabs"
+      @close-pane="onCloseDrilldownPanel"
+      @tab-click="onDrilldownTabClick"
+    >
+      <metadata-pane
+        v-if="drilldownActiveTabId === 'metadata'"
+        slot="content"
+        :data="drilldownMetadata"
+        @open-modal="onOpenModalMetadata"
+      />
+      <parameters-pane
+        v-if="drilldownActiveTabId === 'parameters'"
+        slot="content" :data="drilldownParameters"
+        :related="drilldownRelatedParameters"
+        @open-modal="onOpenModalParameters"
+      />
+      <knowledge-pane
+        v-if="drilldownActiveTabId === 'knowledge'"
+        slot="content"
+        :data="drilldownKnowledge"
+      />
     </drilldown-panel>
+
     <modal-parameters
       v-if="showModalParameters"
       :data="modalDataParameters"
       @close="showModalParameters = false"
-     />
-     <modal-doc-metadata
+    />
+    <modal-doc-metadata
       v-if="showModalMetadata"
       :data="modalDataMetadata"
       @close="showModalMetadata = false"
-     />
+    />
   </div>
 </template>
 
@@ -168,6 +207,7 @@
     drilldownRelatedParameters: any = null;
     drilldownParameters: any = null;
 
+    displaySearch: boolean = false;
     isSplitView = false;
     subgraph: SubgraphInterface = null;
     showModalParameters: boolean = false;
@@ -350,5 +390,45 @@
 <style scoped>
   .left-side-panel {
     flex-shrink: 0;
+  }
+
+  .view-container section {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    position: relative;
+  }
+
+  header {
+    align-items: center;
+    background-color: var(--bg-secondary);
+    display: flex;
+    flex-direction: row;
+    gap: 2em;
+    justify-content: space-between;
+    padding: 10px 5px;
+  }
+
+  header .btn-sim {
+    width: 10.5em; /* Same as the close button on the simulation view */
+  }
+
+  .search-bar {
+    background-color: var(--bg-secondary);
+    max-height: 0;
+    overflow: hidden;
+    pointer-events: none; /* Avoid potential clicks to happen */
+    transition: max-height 250ms ease-in-out;
+    will-change: max-height;
+  }
+
+  .search-bar.active {
+    max-height: 10rem; /* Random number bigger than actual height for the transition. */
+    pointer-events: auto;
+  }
+
+  .search-bar .search-bar-container {
+    margin-top: 0; /* To have an uniform spacing between the header and the search bar */
+    margin-bottom: 10px; /* To match the header vertical spacing */
   }
 </style>

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -425,6 +425,7 @@
   .search-bar.active {
     max-height: 10rem; /* Random number bigger than actual height for the transition. */
     pointer-events: auto;
+    overflow: visible;
   }
 
   .search-bar .search-bar-container {

--- a/client/src/views/Simulation/Simulation.vue
+++ b/client/src/views/Simulation/Simulation.vue
@@ -7,12 +7,12 @@
         @click="displaySearch = !displaySearch"
       >
         <font-awesome-icon :icon="['fas', 'search' ]" />
-        <span>Search</span>
+        Search
       </button>
 
       <button class="btn btn-primary">
         <font-awesome-icon :icon="['fas', 'project-diagram' ]" />
-        <span>Provenance Graph</span>
+        Provenance Graph
       </button>
 
       <div class="runs-controls">
@@ -40,9 +40,12 @@
         </div>
       </div>
 
-      <button class="btn btn-primary" @click="onCloseSimView">
+      <button
+        class="btn-sim btn btn-primary"
+        @click="onCloseSimView"
+      >
         <font-awesome-icon :icon="['fas', 'sign-out-alt' ]" />
-        <span> Close Simulation </span>
+        Close Simulation
       </button>
     </header>
 
@@ -240,6 +243,10 @@
     padding: 10px 5px;
   }
 
+  header .btn-sim {
+    width: 10.5em; /* Same as the close button on the simulation view */
+  }
+
   .search-bar {
     background-color: var(--bg-secondary);
     max-height: 0;
@@ -254,7 +261,7 @@
     pointer-events: auto;
   }
 
-  .search-bar.settings-bar-container {
+  .search-bar .search-bar-container {
     margin-top: 0; /* To have an uniform spacing between the header and the search bar */
     margin-bottom: 10px; /* To match the header vertical spacing */
   }


### PR DESCRIPTION
**What**
- After changing the search bar on the simulation view, the model view was not on par.

**How**
- Clean up the Model view code and implemented the same ideas.
- Random cleanup around.

**Testing**
- The search bar is now hidden behind a toggle button, and the open simulation button match the close button on the simulation view.