### PR TITLE
Fix of a couple of issues in the `main` branch

### DIFF
--- a/client/src/static/mockedDataDemo.ts
+++ b/client/src/static/mockedDataDemo.ts
@@ -11,7 +11,6 @@ export const staticFileURLs = [
   `${window.location.origin}/gromets/SEIR_gromet_PetriNetClassic_metadata.json`,
   `${window.location.origin}/gromets/SEIRD_gromet_PetriNetClassic_metadata.json`,
   `${window.location.origin}/gromets/SIRD_gromet_PetriNetClassic_metadata.json`,
-  `${window.location.origin}/gromets/SIR_AlgebraicJulia.json`,
 ];
 
 // eslint-disable-next-line

--- a/client/src/static/mockedDataDemo.ts
+++ b/client/src/static/mockedDataDemo.ts
@@ -41,7 +41,7 @@ export const buildInitialModelsList = ({ SIR_PN, SIR_FN, SEIR_PN, SEIRD_PN, SIRD
           },
         },
         {
-          donuType: Donu.Type.GROMET_PRT,
+          donuType: Donu.Type.GROMET_PNC, // to replace with GrFN type once donu puts those in
           model: 'sir.easel',
           type: Model.GraphTypes.FunctionNetwork,
           metadata: SIR_FN.metadata,

--- a/client/src/static/mockedDataDemo.ts
+++ b/client/src/static/mockedDataDemo.ts
@@ -41,7 +41,7 @@ export const buildInitialModelsList = ({ SIR_PN, SIR_FN, SEIR_PN, SEIRD_PN, SIRD
           },
         },
         {
-          donuType: Donu.Type.GROMET_PNC, // to replace with GrFN type once donu puts those in
+          donuType: Donu.Type.GROMET_PNC, // TODO: to replace with GrFN type once donu puts those in
           model: 'sir.easel',
           type: Model.GraphTypes.FunctionNetwork,
           metadata: SIR_FN.metadata,


### PR DESCRIPTION
- Removed the `AlgebraicJulia.json` url error as soon as we open the Models view.
- Since Galois is still working on including and executing GrFNs, I just set the GrFN donu type to PNC in the meantime so we can switch to see the GrFN model. 

To test:

- As soon as you open the Models view, you shouldn't get an error anymore.
- Select the SIR model and switch to the Function Network modeling type, it should load normally. 