### PR TITLE
Add small label on the parameter axis

### DIFF
--- a/client/src/utils/SVGUtil.ts
+++ b/client/src/utils/SVGUtil.ts
@@ -43,7 +43,7 @@ export const axis = (range, rangeMin, rangeMax) => {
  * but round up to the nearest power of 10.
  * i.e.  [-12, -4, 0.04] -> [-100, 1]
  */
-export const extendRoundUpToPow10 = (range, accessor) => {
+export const extendRoundUpToPow10 = (range, accessor): [number, number] => {
   let [min, max] = d3.extent(range, accessor);
   min = RoundToPow10(min);
   max = RoundToPow10(max);

--- a/client/src/views/Simulation/components/ParametersPanel.vue
+++ b/client/src/views/Simulation/components/ParametersPanel.vue
@@ -109,6 +109,7 @@
   import { InjectReactive, Prop, Watch } from 'vue-property-decorator';
   import * as d3 from 'd3';
   import svgUtil from '@/utils/SVGUtil';
+  import { shorterNb } from '@/utils/NumberUtil';
   import * as HMI from '@/types/types';
   import Counters from '@/components/Counters.vue';
   import SettingsBar from '@/components/SettingsBar.vue';
@@ -262,9 +263,20 @@
               .attr('class', d => d + ' axis')
               .attr('transform', d => svgUtil.translate(0, yScale(d)));
 
-            g.append('line').attr('x1', xMinMax[0]).attr('x2', xMinMax[1]); // the axis
-            g.append('text').attr('x', xMinMax[0]).text(d => xScales.get(d).min); // min label
-            g.append('text').attr('x', xMinMax[1]).text(d => xScales.get(d).max); // max label
+            // the axis
+            g.append('line')
+              .attr('x1', xMinMax[0])
+              .attr('x2', xMinMax[1]);
+
+            // min label
+            g.append('text')
+              .attr('x', xMinMax[0])
+              .text(d => shorterNb(xScales.get(d).min));
+
+            // max label
+            g.append('text')
+              .attr('x', xMinMax[1])
+              .text(d => shorterNb(xScales.get(d).max));
 
             return g;
           });


### PR DESCRIPTION
**What**
- Display scale on the parameter panel on the simulation view.

**How**
- Save the new roundup to pow10 range of the parameters.
- When adding the axis `<line>`, we also add two `<text>` labelled with min, max of the range.
- Group both the line and the labels in a group and translate the group as a whole.
- Made the label as dark and small as possible to maintain WCAG AA.
- Use scientific notation for big numbers.

**Screenshot**

![Screen Shot 2021-07-21 at 14 58 21](https://user-images.githubusercontent.com/636801/126544523-b0be929d-ad54-49fd-86e6-d24824b13750.png)

