### PR TITLE
Move the parameter action button

### DIFF
--- a/client/src/views/Simulation/components/ParametersPanel.vue
+++ b/client/src/views/Simulation/components/ParametersPanel.vue
@@ -310,8 +310,8 @@
   .parameter {
     display: grid;
     grid-template-areas:
-      ". . action"
-      "name . ."
+      ". . ."
+      "name . action"
       "value . ."
     ;
     grid-template-columns: min-content auto min-content;


### PR DESCRIPTION
**What**
- Move the parameter action button from the top-right to the middle-right

**How**
- Change the CSS grid template.

**Screenshot**

![Screen Shot 2021-07-21 at 16 37 30](https://user-images.githubusercontent.com/636801/126557285-78ea87eb-7c9d-4609-9d26-ba9a1ed31558.png)
