### PR TITLE
Update svg-flowgraph to the latest version and remove collapse node animation

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -44,7 +44,7 @@
     "preact": "8.x",
     "research": "git+https://github.com/uncharted-aske/research.git",
     "sigma": "1.2.1",
-    "svg-flowgraph": "^0.2.0",
+    "svg-flowgraph": "^0.4.0",
     "tiny-emitter": "^2.1.0",
     "tweakpane": "^1.5.8",
     "vue": "^2.6.12",

--- a/client/src/views/GraphExperiment/GraphExperiment.vue
+++ b/client/src/views/GraphExperiment/GraphExperiment.vue
@@ -129,6 +129,7 @@
           } else {
             this.renderer.collapse(id);
           }
+          this.renderer.render();
         }
       });
 

--- a/client/src/views/Models/components/Graphs/GlobalGraph.vue
+++ b/client/src/views/Models/components/Graphs/GlobalGraph.vue
@@ -90,6 +90,7 @@
           } else {
             this.renderer.collapse(id);
           }
+          this.renderer.render();
         } else {
           const neighborhood = calculateNodeNeighborhood(this.data, node.datum());
           this.renderer.showSubgraph(neighborhood);
@@ -146,7 +147,8 @@
       // seems to create problems with the tracker.
       const collapsedIds = calcNodesToCollapse(this.layout, this.renderer.layout);
       if (collapsedIds.length > 0) {
-        collapsedIds.forEach((nextId, i) => setTimeout(() => this.renderer.collapse(nextId), i * 500));
+        collapsedIds.forEach(nextId => this.renderer.collapse(nextId));
+        this.renderer.render();
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6246,10 +6246,10 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-svg-flowgraph@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/svg-flowgraph/-/svg-flowgraph-0.2.0.tgz#e992fd8deaeadfaa92c571c9f96810e2373ad1fb"
-  integrity sha512-4P9j0gaW0F0RYhSkgCqhRgVnKsJxKpAPH8fZoepWvKUT7sfYO0lIbp4Eb+eN8aV9Rr+w6KYrKip9eY06nO5zTA==
+svg-flowgraph@^0.4.0:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/svg-flowgraph/-/svg-flowgraph-0.4.4.tgz#32b84a3f9c13b87a0296222934c3de9a59d2bd00"
+  integrity sha512-bE1WzYRJYlz6pV7O5V784N8igGeZ2wt5RXM8RtyN+3NNKoCQgemp4Vg53HQ8xeuCuoT6KKL2vRePMnLKT34mGw==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
Updated `svg-flowgraph` to latest version from 0.2.0 to 0.4.4 to take advantage of the interface change which removes render from `collapse` and `expand`, hence allowing either function to be called for a list of nodes to be collapsed/expanded without having to wait for the render for each to finish before the next can be called. This requires calling `yarn install` before running.

As this is a library update, its worth testing components using `svg-flowgraph` to ensure there aren't any bugs introduced.

Also note, there is a flash of fully expanded graph before the collapsed version is shown, I have not found a way to remove this.

https://user-images.githubusercontent.com/14062458/126690897-838eaee5-507c-4979-953f-822b6c00780c.mov

