### PR TITLE
Upgrade bgraph to v0.3.2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/vue-fontawesome": "^2.0.0",
     "@types/chroma-js": "^2.1.3",
-    "@uncharted.software/bgraph": "0.2.0",
+    "@uncharted.software/bgraph": "0.3.2",
     "@uncharted.software/facets-core": "^3.1.0",
     "@uncharted.software/facets-plugins": "^3.1.0",
     "@uncharted.software/grafer": "^0.3.4",

--- a/client/src/utils/BGraphUtil.ts
+++ b/client/src/utils/BGraphUtil.ts
@@ -131,9 +131,10 @@ export const filterToBgraph = (bgraph: any, filters: Filters): any => {
 
         // Append path query results
         // TODO: Consider adding a way to flatten paths as a bgraph pipeline step
-        const path = bgraphPathQueryResults[i].state?.path || [];
-        for (const vertex of path) {
-          flattenedBGraphPathQueryResults.push(vertex);
+        let currPath = bgraphPathQueryResults[i].state?.path;
+        while (currPath) {
+          flattenedBGraphPathQueryResults.push(currPath.vertex);
+          currPath = currPath.parent;
         }
       }
       const bgraphQueryResults = _.uniqBy(flattenedBGraphPathQueryResults, '_id');

--- a/yarn.lock
+++ b/yarn.lock
@@ -579,10 +579,10 @@
     "@typescript-eslint/types" "4.4.0"
     eslint-visitor-keys "^2.0.0"
 
-"@uncharted.software/bgraph@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@uncharted.software/bgraph/-/bgraph-0.2.0.tgz#45b27bb364ffdbfc10c33f7a2e82ae5a10f58119"
-  integrity sha512-LofN+5e/MKYrUAYkEvGQaPlcveBx0tclSXD16YQXig2SBmwnDze4oKSAIdda8fYQajrUjs17LfEuU1RR4eQsWQ==
+"@uncharted.software/bgraph@0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@uncharted.software/bgraph/-/bgraph-0.3.2.tgz#07f5fd88e9e316d8785a499dbf8a2dfd7314cd86"
+  integrity sha512-YE9pKqU5Ho52wQNVtg8TFkgaSthxMjhiQLf8LoKpWKh9yVoqV87XvG8VYY/3WsKXDoOX9Cg8lG+hK6k1DYXMQw==
 
 "@uncharted.software/css-options@^3.1.0":
   version "3.1.0"


### PR DESCRIPTION
### Description
Upgrade bgraph library from v0.2.0 to v0.3.2. (See release notes: https://github.com/uncharted-aske/bgraph/releases/tag/v0.3.2)

### Changes
- Bump bgraph package to v0.3.2
- Modify path flattening to account for change in bgraph interface

### Considerations
- Performance improvements were not adequate for covid19 graph (only a ~2x improvement). There still remains a performance issue. Changes in the bgraph release improved path queries on sparse graphs with longer paths (typical of functional networks) much more then it did dense graphs with short paths (covid19).

### Testing
- Ensure to `yarn install` before testing.

### Artifacts
bgraph **v0.2.0** profiling over covid19 model using path query `Organisms -> small molecule`:
![Screen Shot 2021-07-27 at 11 12 18 AM](https://user-images.githubusercontent.com/15199528/127183421-985ba4bf-d8b5-4e8a-a861-01d02265c394.png)

bgraph **v0.3.2** profiling over covid19 model using path query `Organisms -> small molecule`:
![Screen Shot 2021-07-27 at 11 09 39 AM](https://user-images.githubusercontent.com/15199528/127183443-eab62ece-5c7d-4059-936c-845470d7d32b.png)

