### PR TITLE
Add in-memory size limit to fetch memoization system and implemented for donu service

### DIFF
--- a/client/src/services/DonuService.ts
+++ b/client/src/services/DonuService.ts
@@ -2,7 +2,7 @@ import { GroMEt2Graph } from 'research/gromet/tools/parser/GroMEt2Graph';
 
 import * as Donu from '@/types/typesDonu';
 import * as Model from '@/types/typesModel';
-import { postUtil } from '@/utils/FetchUtil';
+import { postUtil, postUtilMem } from '@/utils/FetchUtil';
 
 /** Send the request to Donu */
 const callDonu = (request: Donu.Request): Promise<Donu.Response> => {
@@ -109,7 +109,7 @@ export const getModelParameters = async (model: Model.Model, selectedModelGraphT
       } as Donu.ModelDefinition,
     };
 
-    const response = await callDonu(request);
+    const response = await postUtilMem(process.env.DONU_ENDPOINT, request);
     if (response.status === Donu.ResponseStatus.success) {
       const result = response?.result as Donu.ModelDefinition;
       return result?.parameters ?? null;
@@ -134,7 +134,7 @@ export const getModelVariables = async (model: Model.Model, selectedModelGraphTy
       } as Donu.ModelDefinition,
     };
 
-    const response = await callDonu(request);
+    const response = await postUtilMem(process.env.DONU_ENDPOINT, request);
     if (response.status === Donu.ResponseStatus.success) {
       const result = response?.result as Donu.ModelDefinition;
       return result?.measures ?? null;
@@ -166,8 +166,7 @@ export const getModelResult = async (
       start: config.start,
       step: config.step,
     };
-
-    const response = await callDonu(request);
+    const response = await postUtilMem(process.env.DONU_ENDPOINT, request);
     if (response.status === Donu.ResponseStatus.success) {
       return response?.result as Donu.SimulationResponse ?? null;
     } else {

--- a/client/src/services/DonuService.ts
+++ b/client/src/services/DonuService.ts
@@ -13,6 +13,14 @@ const callDonu = (request: Donu.Request): Promise<Donu.Response> => {
   }
 };
 
+const callDonuCache = (request: Donu.Request): Promise<Donu.Response> => {
+  try {
+    return postUtilMem(process.env.DONU_ENDPOINT, request);
+  } catch (error) {
+    console.error('[DONU Service] — callDonu', error); // eslint-disable-line no-console
+  }
+};
+
 const getDonuModelSource = async (model: string, type: Donu.Type): Promise<Donu.ModelGraph> => {
   const request: Donu.Request = {
     command: Donu.RequestCommand.GET_MODEL_SOURCE,
@@ -109,7 +117,7 @@ export const getModelParameters = async (model: Model.Model, selectedModelGraphT
       } as Donu.ModelDefinition,
     };
 
-    const response = await postUtilMem(process.env.DONU_ENDPOINT, request);
+    const response = await callDonuCache(request);
     if (response.status === Donu.ResponseStatus.success) {
       const result = response?.result as Donu.ModelDefinition;
       return result?.parameters ?? null;
@@ -134,7 +142,7 @@ export const getModelVariables = async (model: Model.Model, selectedModelGraphTy
       } as Donu.ModelDefinition,
     };
 
-    const response = await postUtilMem(process.env.DONU_ENDPOINT, request);
+    const response = await callDonuCache(request);
     if (response.status === Donu.ResponseStatus.success) {
       const result = response?.result as Donu.ModelDefinition;
       return result?.measures ?? null;
@@ -166,7 +174,8 @@ export const getModelResult = async (
       start: config.start,
       step: config.step,
     };
-    const response = await postUtilMem(process.env.DONU_ENDPOINT, request);
+
+    const response = await callDonuCache(request);
     if (response.status === Donu.ResponseStatus.success) {
       return response?.result as Donu.SimulationResponse ?? null;
     } else {


### PR DESCRIPTION
The goal of this PR is to add memoization back to the donu simulate fetch. This will make the simulate view more responsive by eliminating most redundant API calls to donu and solves issue #297. To test, ensure the simulate page is working properly, one should notice a slight increase in responsiveness particularly with a large number of runs.

In order to address previous concerns with the current memoization system with high memory usage and memory leaks, the system was modified to track the size of each entry stored in bytes and limit the total amount of memory consumed by the store to a specified number of bytes. If the store fills up it will drop entries starting from the first one stored until there is sufficient space for a new entry to be stored.

The two parameters controlling the behaviour of the memoization store are the `storeSizeLimit` (discussed above) limiting the total size of the store; and the `storeEntryLimit` limiting the size of each entry. If an item exceeds the `storeEntryLimit` it is not stored at all.