### PR TITLE
Use GSL engine for petri net classic simulation

### DIFF
--- a/client/src/services/DonuService.ts
+++ b/client/src/services/DonuService.ts
@@ -146,6 +146,14 @@ export const getModelVariables = async (model: Model.Model, selectedModelGraphTy
   }
 };
 
+const getSimulationType = (modelType: Donu.Type): Donu.SimulationType | void => {
+  if (modelType === Donu.Type.GROMET_PNC) {
+    // HACK: Donu defaults to Algebraic Julia as the sim engine for Petri Net Classics.
+    // here we've temporarily overwritten to use GSL as algebraic julia contains a bug
+    return Donu.SimulationType.GSL;
+  }
+};
+
 /** Fetch the result of a model simulation */
 export const getModelResult = async (
   model: Model.Model,
@@ -157,6 +165,8 @@ export const getModelResult = async (
   if (modelGraph) {
     const request: Donu.Request = {
       command: Donu.RequestCommand.SIMULATE,
+      // HACK: get simulation type is a temporary solution while the Donu service fixes their simulation engine calls
+      'sim-type': getSimulationType(modelGraph.donuType as Donu.Type),
       definition: {
         source: { model: modelGraph.model },
         type: modelGraph.donuType as Donu.Type,

--- a/client/src/types/typesDonu.ts
+++ b/client/src/types/typesDonu.ts
@@ -23,6 +23,13 @@ enum Type {
   GROMET_PRT = 'gromet-prt',
 }
 
+enum SimulationType {
+  ALGEBRAIC_JULIA = 'aj', // Supports petri net classic models
+  DISCRETE = 'discrete', // Supports discrete models
+  GSL = 'gsl', // Supports petri net classic and place/transition net models
+  AUTOMATES = 'automates', // Supports functional networks
+}
+
 type Metadata = {
   description?: string,
   group?: string,
@@ -86,6 +93,7 @@ type Request = {
   // name?: string;
   start?: number;
   step?: number;
+  'sim-type'?: SimulationType | void,
   // type?: string;
 }
 
@@ -122,4 +130,5 @@ export {
   ModelGraph,
   SimulationResponse,
   Type,
+  SimulationType,
 };


### PR DESCRIPTION
### Description
Temporarily use GSL engine as default for petri net classic simulations as currently Donu API contains a bug when using Algebraic Julia as default.

### Changes
- Add simulation engine types
- Override default simulation engine for petri net classic model types

### Considerations
- This is a temporary change while Donu is being fixed.

### Testing
- I used the SimpleSIR model for testing.

### Artifacts
![Screen Shot 2021-07-27 at 4 40 28 PM](https://user-images.githubusercontent.com/15199528/127225202-63c97ac5-1016-4819-b9ff-8438542f0454.png)

