### PR TITLE
Update GroMet visual encodings

### DIFF
--- a/client/src/graphs/svg/dagre/adapter.js
+++ b/client/src/graphs/svg/dagre/adapter.js
@@ -2,6 +2,8 @@
 import { traverse } from '@/graphs/svg/util';
 import dagre from 'dagre';
 
+import { NodeTypes } from '@/graphs/svg/encodings.ts';
+
 export default class DagreAdapter {
   constructor (options) {
     this.nodeWidth = options.nodeWidth;
@@ -16,7 +18,7 @@ export default class DagreAdapter {
         node.height = this.nodeHeight;
 
         // Special case for parameters
-        if (node?.data.role?.includes('parameter')) {
+        if (node.data && node.data.role?.includes(NodeTypes.NODES.PARAMETER)) {
           node.width = this.parameterNodeSize || 30;
           node.height = this.parameterNodeSize || 30;
         }

--- a/client/src/graphs/svg/elk/adapter.js
+++ b/client/src/graphs/svg/elk/adapter.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import ELK from 'elkjs/lib/elk.bundled';
 import { layered } from '@/graphs/svg/elk/layouts';
 
+import { NodeTypes } from '@/graphs/svg/encodings.ts';
 import { makeEdgeMaps, traverse, changeKey } from '@/graphs/svg/util.js';
 
 /**
@@ -80,7 +81,7 @@ const injectELKOptions = (renderGraph, options) => {
       node.height = node.height || options.nodeHeight;
 
       // Special case for parameters
-      if (node.data && node.data.role?.includes('parameter')) {
+      if (node.data && node.data.role?.includes(NodeTypes.NODES.PARAMETER)) {
         node.width = options.parameterNodeSize || 30;
         node.height = options.parameterNodeSize || 30;
       }

--- a/client/src/graphs/svg/encodings.ts
+++ b/client/src/graphs/svg/encodings.ts
@@ -1,14 +1,13 @@
 export abstract class Colors {
   static readonly HIGHLIGHT: string = '#EBCB8B';
   static readonly STROKE: string = '#81A1C1';
+  static readonly CONTAINER_CONTROL: string = '#D08770';
 
   static readonly NODES: Record<string, any> = {
     DEFAULT: '#ECEFF4',
     EDITED: '#D08770',
 
-    // Gromet
     CONTAINER: '#2E3440',
-    VARIABLE: '#E75BCD',
   };
 
   // Bio graphs

--- a/client/src/graphs/svg/encodings.ts
+++ b/client/src/graphs/svg/encodings.ts
@@ -1,17 +1,14 @@
 export abstract class Colors {
-  static readonly SUBGRAPH: string = '#FFA500';
   static readonly HIGHLIGHT: string = '#EBCB8B';
   static readonly STROKE: string = '#81A1C1';
 
   static readonly NODES: Record<string, any> = {
     DEFAULT: '#ECEFF4',
-    AGGREGATE: Colors.HIGHLIGHT,
-    OVERLAPPING: Colors.HIGHLIGHT,
     EDITED: '#D08770',
 
     // Gromet
     CONTAINER: '#2E3440',
-    VARIABLE: '#88C0D0',
+    VARIABLE: '#E75BCD',
   };
 
   // Bio graphs
@@ -30,7 +27,6 @@ export abstract class Colors {
 
   static readonly EDGES: Record<string, any> = {
     DEFAULT: '#c2c7d1',
-    OVERLAPPING: Colors.HIGHLIGHT,
   };
 
   static readonly LABELS: Record<string, any> = {
@@ -44,14 +40,10 @@ export abstract class Colors {
 export abstract class NodeTypes {
   static readonly NODES: Record<string, any> = {
     // GroMEt roles
-    CONTAINER: 'Box',
     VARIABLE: 'variable',
     PARAMETER: 'parameter',
+    INITIAL_CONDITION: 'initial_condition',
     // GroMEt roles
-
-    OVERLAPPING: 'overlapping',
-    ABSTRACTOVERLAPPING: 'AP',
-    NONOVERLAPPING: 'NOAP',
   }
 }
 
@@ -65,10 +57,6 @@ export abstract class EdgeTypes {
     PHOSPORYLATION: 'Phosporylation',
     DEPHOSPORYLATION: 'Dephosporylation',
     COMPLEX: 'Complex',
-
-    OVERLAPPING: 'overlapping',
-    ABSTRACTOVERLAPPING: 'AP',
-    NONOVERLAPPING: 'NOAP',
   }
 
   static readonly CURATION_STATUS: Record<string, any> = {

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -157,7 +157,7 @@ export default class EpiRenderer extends SVGRenderer {
           .attr('x', d => (d as any).width - 12)
           .attr('y', (DEFAULT_STYLE.node.controlSize / 2) + 10)
           .style('fill', Colors.LABELS.LIGHT)
-          .style('font-weight', '500')
+          .style('font-weight', 'bold')
           .style('text-anchor', 'middle')
           .text(d=> (d as any).collapsed ? '+' : '-');
       }
@@ -166,7 +166,7 @@ export default class EpiRenderer extends SVGRenderer {
         .attr('x', d => (d as any).nodes ? 0 : 0.5 * (d as any).width)
         .attr('y', d => (d as any).nodes ? -5 : 25)
         .style('fill', d => calcLabelColor(d))
-        .style('font-weight', d => (d as any).nodes ? '1000' : '500')
+        .style('font-weight', d => (d as any).nodes ? 'bold' : 'normal')
         .style('text-anchor', d => (d as any).nodes ? 'left' : 'middle')
         .text(d => (d as any).data.label);
 
@@ -232,8 +232,14 @@ export default class EpiRenderer extends SVGRenderer {
 
   clearSelections ():void {
     const chart = (this as any).chart;
-    chart.selectAll('rect, ellipse')
-      .style('stroke', DEFAULT_STYLE.node.stroke)
-      .style('stroke-width', DEFAULT_STYLE.node.strokeWidth);
+    chart
+      .selectAll('.node-ui').each(function(d) {
+        if (!d.nodes) {
+          d3.select(this).select('rect, ellipse')
+          .style('stroke', DEFAULT_STYLE.node.stroke)
+          .style('stroke-width', DEFAULT_STYLE.node.strokeWidth);
+        }
+      });
+      
   }
 }

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -43,7 +43,9 @@ export default class EpiRenderer extends SVGRenderer {
   }
 
   static calcNodeStrokeWidth (d: d3.Selection<any, any, any, any>): number {
-    return !(d as any).nodes && !(d as any).data.role?.includes(NodeTypes.NODES.VARIABLE) ? DEFAULT_STYLE.node.strokeWidth + 1 : DEFAULT_STYLE.node.strokeWidth;
+    if (!(d as any).nodes && !(d as any).data.role?.includes(NodeTypes.NODES.VARIABLE)) {
+      return DEFAULT_STYLE.node.strokeWidth + 1;
+    } else return DEFAULT_STYLE.node.strokeWidth;
   }
 
   buildDefs (): void {

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -14,7 +14,7 @@ const DEFAULT_STYLE = {
   node: {
     fill: Colors.NODES.DEFAULT,
     stroke: Colors.STROKE,
-    strokeWidth: 1,
+    strokeWidth: 2,
     borderRadius: 5,
   },
   edge: {
@@ -36,8 +36,12 @@ export default class EpiRenderer extends SVGRenderer {
     return (d as any).nodes ? Colors.NODES.CONTAINER : DEFAULT_STYLE.node.fill;
   }
 
+  static calcNodeStrokeStyle (d: d3.Selection<any, any, any, any>): string {
+    return !(d as any).nodes && !(d as any).data.role?.includes(NodeTypes.NODES.VARIABLE) ? `5,5` : null;
+  }
+
   static calcNodeStrokeWidth (d: d3.Selection<any, any, any, any>): number {
-    return (d as any).data.role?.includes(NodeTypes.NODES.VARIABLE) ? 3 : DEFAULT_STYLE.node.strokeWidth;
+    return !(d as any).nodes && !(d as any).data.role?.includes(NodeTypes.NODES.VARIABLE) ? DEFAULT_STYLE.node.strokeWidth + 1 : DEFAULT_STYLE.node.strokeWidth;
   }
 
   buildDefs (): void {
@@ -69,7 +73,7 @@ export default class EpiRenderer extends SVGRenderer {
       .attr('xoverflow', 'visible')
       .append('svg:path')
       .attr('d', SVGUtil.ARROW)
-      .style('fill', DEFAULT_STYLE.edge.stroke)
+      .style('fill', Colors.EDGES.DEFAULT)
       .style('stroke', 'none');
 
     // Create filter with id #drop-shadow for containers
@@ -121,6 +125,7 @@ export default class EpiRenderer extends SVGRenderer {
           .style('fill', EpiRenderer.calcNodeColor)
           .style('stroke', DEFAULT_STYLE.node.stroke)
           .style('stroke-width', EpiRenderer.calcNodeStrokeWidth)
+          .style('stroke-dasharray', EpiRenderer.calcNodeStrokeStyle)
           .style('cursor', 'pointer');
       } else {
         selection.append('ellipse')
@@ -131,6 +136,7 @@ export default class EpiRenderer extends SVGRenderer {
           .style('fill', EpiRenderer.calcNodeColor)
           .style('stroke',DEFAULT_STYLE.node.stroke)
           .style('stroke-width', EpiRenderer.calcNodeStrokeWidth)
+          .style('stroke-dasharray', EpiRenderer.calcNodeStrokeStyle)
           .style('cursor', 'pointer');
       }
 
@@ -142,7 +148,7 @@ export default class EpiRenderer extends SVGRenderer {
         .style('text-anchor', d => (d as any).nodes ? 'left' : 'middle')
         .text(d => (d as any).data.label);
 
-      // Special case for node parameters
+      // Special case for node parameters labels
       selection.selectAll('text')
         .filter(d => (d as any).data.role?.includes(NodeTypes.NODES.PARAMETER)).attr('y', -5);
     });
@@ -188,7 +194,7 @@ export default class EpiRenderer extends SVGRenderer {
   }
 
   selectNode (node: d3.Selection<any, any, any, any>): void {
-    node.select('rect')
+    node.selectAll('rect, ellipse')
       .style('stroke', Colors.HIGHLIGHT)
       .style('stroke-width', DEFAULT_STYLE.node.strokeWidth + 3);
   }

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -36,8 +36,8 @@ export default class EpiRenderer extends SVGRenderer {
     return (d as any).nodes ? Colors.NODES.CONTAINER : DEFAULT_STYLE.node.fill;
   }
 
-  static calcNodeStroke (d: d3.Selection<any, any, any, any>): string {
-    return (d as any).data.role?.includes(NodeTypes.NODES.VARIABLE) ? Colors.NODES.VARIABLE : DEFAULT_STYLE.node.stroke;
+  static calcNodeStrokeWidth (d: d3.Selection<any, any, any, any>): number {
+    return (d as any).data.role?.includes(NodeTypes.NODES.VARIABLE) ? 3 : DEFAULT_STYLE.node.strokeWidth;
   }
 
   buildDefs (): void {
@@ -109,7 +109,7 @@ export default class EpiRenderer extends SVGRenderer {
     nodeSelection.each(function () {
       const selection = d3.select(this);
       const datum = selection.datum();
-      
+
       // Initial conditions are displayed as ellipses
       if (!(datum as any).data.role?.includes(NodeTypes.NODES.INITIAL_CONDITION)) {
         selection.append('rect')
@@ -119,21 +119,21 @@ export default class EpiRenderer extends SVGRenderer {
           .attr('width', d => (d as any).width)
           .attr('height', d => (d as any).height)
           .style('fill', EpiRenderer.calcNodeColor)
-          .style('stroke', EpiRenderer.calcNodeStroke)
-          .style('stroke-width', DEFAULT_STYLE.node.strokeWidth)
+          .style('stroke', DEFAULT_STYLE.node.stroke)
+          .style('stroke-width', EpiRenderer.calcNodeStrokeWidth)
           .style('cursor', 'pointer');
       } else {
         selection.append('ellipse')
-              .attr("cx", d => (d as any).width/2)
-              .attr("cy", d => (d as any).height/2)
-              .attr("rx", d => (d as any).width/2)
-              .attr("ry", d => (d as any).height/2)
-              .style('fill', EpiRenderer.calcNodeColor)
-              .style('stroke', EpiRenderer.calcNodeStroke)
-              .style('stroke-width', DEFAULT_STYLE.node.strokeWidth)
-              .style('cursor', 'pointer');      
+          .attr('cx', d => (d as any).width / 2)
+          .attr('cy', d => (d as any).height / 2)
+          .attr('rx', d => (d as any).width / 2)
+          .attr('ry', d => (d as any).height / 2)
+          .style('fill', EpiRenderer.calcNodeColor)
+          .style('stroke',DEFAULT_STYLE.node.stroke)
+          .style('stroke-width', EpiRenderer.calcNodeStrokeWidth)
+          .style('cursor', 'pointer');
       }
-      
+
       selection.append('text')
         .attr('x', d => (d as any).nodes ? 0 : 0.5 * (d as any).width)
         .attr('y', d => (d as any).nodes ? -5 : 25)
@@ -145,7 +145,6 @@ export default class EpiRenderer extends SVGRenderer {
       // Special case for node parameters
       selection.selectAll('text')
         .filter(d => (d as any).data.role?.includes(NodeTypes.NODES.PARAMETER)).attr('y', -5);
-
     });
   }
 

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -128,7 +128,7 @@ export default class EpiRenderer extends SVGRenderer {
           .style('stroke', DEFAULT_STYLE.node.stroke)
           .style('stroke-width', EpiRenderer.calcNodeStrokeWidth)
           .style('stroke-dasharray', EpiRenderer.calcNodeStrokeStyle)
-          .style('cursor', d=> (d as any).nodes ? '' : 'pointer');
+          .style('cursor', d => (d as any).nodes ? '' : 'pointer');
       } else {
         selection.append('ellipse')
           .attr('cx', d => (d as any).width / 2)
@@ -145,21 +145,21 @@ export default class EpiRenderer extends SVGRenderer {
       // Add +/- icon to boxes/containers
       if ((datum as any).nodes) {
         const containerControl = selection.append('g').classed('container-control', true).style('cursor', 'pointer');
-                
+
         containerControl.append('rect')
           .attr('x', d => (d as any).width - 20)
           .attr('y', 5)
           .attr('width', DEFAULT_STYLE.node.controlSize)
           .attr('height', DEFAULT_STYLE.node.controlSize)
           .style('fill', DEFAULT_STYLE.node.controlColor);
-        
+
         containerControl.append('text')
           .attr('x', d => (d as any).width - 12)
           .attr('y', (DEFAULT_STYLE.node.controlSize / 2) + 10)
           .style('fill', Colors.LABELS.LIGHT)
           .style('font-weight', 'bold')
           .style('text-anchor', 'middle')
-          .text(d=> (d as any).collapsed ? '+' : '-');
+          .text(d => (d as any).collapsed ? '+' : '-');
       }
 
       selection.append('text')
@@ -233,13 +233,12 @@ export default class EpiRenderer extends SVGRenderer {
   clearSelections ():void {
     const chart = (this as any).chart;
     chart
-      .selectAll('.node-ui').each(function(d) {
+      .selectAll('.node-ui').each(function (d) {
         if (!d.nodes) {
           d3.select(this).select('rect, ellipse')
-          .style('stroke', DEFAULT_STYLE.node.stroke)
-          .style('stroke-width', DEFAULT_STYLE.node.strokeWidth);
+            .style('stroke', DEFAULT_STYLE.node.stroke)
+            .style('stroke-width', DEFAULT_STYLE.node.strokeWidth);
         }
       });
-      
   }
 }

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -234,9 +234,8 @@ export default class EpiRenderer extends SVGRenderer {
           .style('fill', Colors.HIGHLIGHT)
           .style('stroke', DEFAULT_STYLE.node.stroke)
           .style('stroke-width', DEFAULT_STYLE.node.strokeWidth);
-
       } else {
-          d3.select(this).select('.edited-marker').remove();
+        d3.select(this).select('.edited-marker').remove();
       }
     });
   }

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -131,10 +131,10 @@ export default class EpiRenderer extends SVGRenderer {
           .style('cursor', d => (d as any).nodes ? '' : 'pointer');
       } else {
         selection.append('ellipse')
-          .attr('cx', d => (d as any).width / 2)
-          .attr('cy', d => (d as any).height / 2)
-          .attr('rx', d => (d as any).width / 2)
-          .attr('ry', d => (d as any).height / 2)
+          .attr('cx', d => (d as any).width * 0.5)
+          .attr('cy', d => (d as any).height * 0.5)
+          .attr('rx', d => (d as any).width * 0.5)
+          .attr('ry', d => (d as any).height * 0.5)
           .style('fill', EpiRenderer.calcNodeColor)
           .style('stroke', DEFAULT_STYLE.node.stroke)
           .style('stroke-width', EpiRenderer.calcNodeStrokeWidth)
@@ -221,12 +221,23 @@ export default class EpiRenderer extends SVGRenderer {
       .style('stroke-width', DEFAULT_STYLE.node.strokeWidth + 3);
   }
 
-  highlightNodes (nodesList: SubgraphNodeInterface[]): void {
+  markEditedNodes (nodesList: SubgraphNodeInterface[]): void {
     const chart = (this as any).chart;
     chart.selectAll('.node-ui').each(function (d) {
       const isHighlighted = nodesList.map(node => node.id).includes(d.id);
-      d3.select(this).select('rect')
-        .style('fill', isHighlighted ? Colors.NODES.EDITED : EpiRenderer.calcNodeColor(d));
+      if (isHighlighted) {
+        d3.select(this).append('circle')
+          .classed('edited-marker', true)
+          .attr('cx', d => (d as any).width - 5)
+          .attr('cy', 5)
+          .attr('r', DEFAULT_STYLE.node.controlSize * 0.5)
+          .style('fill', Colors.HIGHLIGHT)
+          .style('stroke', DEFAULT_STYLE.node.stroke)
+          .style('stroke-width', DEFAULT_STYLE.node.strokeWidth);
+
+      } else {
+          d3.select(this).select('.edited-marker').remove();
+      }
     });
   }
 

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -18,7 +18,8 @@ const DEFAULT_STYLE = {
     borderRadius: 5,
   },
   edge: {
-    fill: Colors.EDGES.DEFAULT,
+    fill: 'none',
+    stroke: Colors.EDGES.DEFAULT,
     strokeWidth: 5,
     controlRadius: 6,
     controlStrokeWidth: 2,
@@ -64,7 +65,7 @@ export default class EpiRenderer extends SVGRenderer {
       .attr('xoverflow', 'visible')
       .append('svg:path')
       .attr('d', SVGUtil.ARROW)
-      .style('fill', d => calcEdgeColor(d))
+      .style('fill', DEFAULT_STYLE.edge.stroke)
       .style('stroke', 'none');
 
     // Create filter with id #drop-shadow for containers
@@ -134,7 +135,7 @@ export default class EpiRenderer extends SVGRenderer {
       .attr('d', d => pathFn(d.points))
       .style('fill', DEFAULT_STYLE.edge.fill)
       .style('stroke-width', DEFAULT_STYLE.edge.strokeWidth)
-      .style('stroke', DEFAULT_STYLE.edge.fill)
+      .style('stroke', DEFAULT_STYLE.edge.stroke)
       .attr('marker-end', d => {
         const source = d.source.replace(/\s/g, '');
         const target = d.target.replace(/\s/g, '');

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -4,7 +4,7 @@ import { SVGRenderer } from 'svg-flowgraph';
 
 import { SVGRendererOptionsInterface, SubgraphInterface, SubgraphNodeInterface } from '@/types/typesGraphs';
 
-import { calcEdgeColor, calcLabelColor, flatten } from '@/graphs/svg/util';
+import { calcLabelColor, flatten } from '@/graphs/svg/util';
 import { Colors, NodeTypes } from '@/graphs/svg/encodings';
 import SVGUtil from '@/utils/SVGUtil';
 
@@ -18,7 +18,7 @@ const DEFAULT_STYLE = {
     borderRadius: 5,
   },
   edge: {
-    fill: 'none',
+    fill: Colors.EDGES.DEFAULT,
     strokeWidth: 5,
     controlRadius: 6,
     controlStrokeWidth: 2,
@@ -32,11 +32,7 @@ export default class EpiRenderer extends SVGRenderer {
   }
 
   static calcNodeColor (d: d3.Selection<any, any, any, any>): string {
-    if ((d as any).nodes) {
-      return Colors.NODES.CONTAINER;
-    } else {
-      return (d as any).data.role?.includes(NodeTypes.NODES.VARIABLE) ? Colors.NODES.VARIABLE : DEFAULT_STYLE.node.fill;
-    }
+    return (d as any).nodes ? Colors.NODES.CONTAINER : DEFAULT_STYLE.node.fill;
   }
 
   buildDefs (): void {
@@ -115,7 +111,8 @@ export default class EpiRenderer extends SVGRenderer {
         .attr('height', d => (d as any).height)
         .style('fill', EpiRenderer.calcNodeColor)
         .style('stroke', DEFAULT_STYLE.node.stroke)
-        .style('stroke-width', DEFAULT_STYLE.node.strokeWidth);
+        .style('stroke-width', DEFAULT_STYLE.node.strokeWidth)
+        .style('cursor', 'pointer');
 
       selection.append('text')
         .attr('x', d => (d as any).nodes ? 0 : 0.5 * (d as any).width)
@@ -137,7 +134,7 @@ export default class EpiRenderer extends SVGRenderer {
       .attr('d', d => pathFn(d.points))
       .style('fill', DEFAULT_STYLE.edge.fill)
       .style('stroke-width', DEFAULT_STYLE.edge.strokeWidth)
-      .style('stroke', d => calcEdgeColor(d))
+      .style('stroke', DEFAULT_STYLE.edge.fill)
       .attr('marker-end', d => {
         const source = d.source.replace(/\s/g, '');
         const target = d.target.replace(/\s/g, '');
@@ -148,26 +145,6 @@ export default class EpiRenderer extends SVGRenderer {
         const target = d.target.replace(/\s/g, '');
         return `url(#start-${source}-${target}`;
       });
-  }
-
-  renderEdgeUpdated (edgeSelection: d3.Selection<any, any, any, any>): void {
-    edgeSelection
-      .selectAll('.edge-path')
-      .attr('d', d => {
-        return pathFn((d as any).points);
-      });
-  }
-
-  renderEdgeRemoved (edgeSelection: d3.Selection<any, any, any, any>): void {
-    edgeSelection.each(function () {
-      d3.select(this)
-        .transition()
-        .on('end', function () {
-          d3.select(this).remove();
-        })
-        .duration(1500)
-        .style('opacity', 0.2);
-    });
   }
 
   hideSubgraph (): void {

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -37,7 +37,7 @@ export default class EpiRenderer extends SVGRenderer {
   }
 
   static calcNodeStrokeStyle (d: d3.Selection<any, any, any, any>): string {
-    return !(d as any).nodes && !(d as any).data.role?.includes(NodeTypes.NODES.VARIABLE) ? `5,5` : null;
+    return !(d as any).nodes && !(d as any).data.role?.includes(NodeTypes.NODES.VARIABLE) ? '5,5' : null;
   }
 
   static calcNodeStrokeWidth (d: d3.Selection<any, any, any, any>): number {
@@ -134,7 +134,7 @@ export default class EpiRenderer extends SVGRenderer {
           .attr('rx', d => (d as any).width / 2)
           .attr('ry', d => (d as any).height / 2)
           .style('fill', EpiRenderer.calcNodeColor)
-          .style('stroke',DEFAULT_STYLE.node.stroke)
+          .style('stroke', DEFAULT_STYLE.node.stroke)
           .style('stroke-width', EpiRenderer.calcNodeStrokeWidth)
           .style('stroke-dasharray', EpiRenderer.calcNodeStrokeStyle)
           .style('cursor', 'pointer');

--- a/client/src/graphs/svg/util.js
+++ b/client/src/graphs/svg/util.js
@@ -139,26 +139,6 @@ export const calculateEdgeNeighborhood = (edge) => {
   };
 };
 
-export const calcNodeColor = (node) => {
-  if (node.nodes) {
-    // Distinction between the main container and the rest
-    return node.depth === 2 ? Colors.NODES.ROOT_CONTAINER : Colors.NODES.CONTAINER;
-  } else
-  if (node.nodeType === NodeTypes.NODES.VARIABLE) {
-    if (node.nodeSubType) {
-      if (node.nodeSubType.includes(NodeTypes.VARIABLES.MODEL_VARIABLE)) {
-        return Colors.NODES.MODEL_VARIABLE;
-      }
-      if (node.nodeSubType.includes(NodeTypes.VARIABLES.INITIAL_CONDITION)) {
-        return Colors.NODES.INITIAL_CONDITION;
-      }
-    }
-  } else if (node.nodeType === NodeTypes.NODES.OVERLAPPING) {
-    return Colors.NODES.OVERLAPPING;
-  }
-  return Colors.NODES.DEFAULT;
-};
-
 export const calcLabelColor = (node) => {
   if (node.nodes) {
     return Colors.LABELS.LIGHT;

--- a/client/src/views/Models/components/Graphs/GlobalGraph.vue
+++ b/client/src/views/Models/components/Graphs/GlobalGraph.vue
@@ -30,7 +30,7 @@
   export default class GlobalGraph extends Vue {
     @Prop({ default: null }) data: GraphInterface;
     @Prop({ default: null }) subgraph: SubgraphInterface;
-    @Prop({ default: () => [] }) highlightedNodes: SubgraphNodeInterface[];
+    @Prop({ default: () => [] }) editedNodes: SubgraphNodeInterface[];
     @Prop({ default: GraphLayoutInterfaceType.elk }) layout: string;
 
     renderingOptions = DEFAULT_RENDERING_OPTIONS;
@@ -52,9 +52,9 @@
       this.subgraphChanged();
     }
 
-    @Watch('highlightedNodes')
-    async highlightedNodesChanged (): Promise<void> {
-      this.renderer.highlightNodes(this.highlightedNodes);
+    @Watch('editedNodes')
+    async editedNodesChanged (): Promise<void> {
+      this.renderer.markEditedNodes(this.editedNodes);
     }
 
     subgraphChanged (): void {
@@ -100,19 +100,6 @@
           this.$emit('node-click', node.datum().data);
         }
       });
-
-      // this.renderer.setCallback('nodeMouseEnter', (evt, node, /**renderer*/) => {
-      //   if (!node.datum().nodes) {
-      //     const data = node.datum();
-      //     /* @ts-ignore */
-      //     // showTooltip(renderer.chart, data.label, [data.x + data.width / 2, data.y]); // Fixme: tooltips for nodes within a container are not properly placed
-      //   }
-      // });
-
-      // this.renderer.setCallback('nodeMouseLeave', (evt, node, renderer) => {
-      //   if (node.datum().nodes) return;
-      //   // hideTooltip(renderer.chart);
-      // });
 
       this.renderer.setCallback('backgroundClick', () => {
           this.renderer.hideSubgraph();

--- a/client/src/views/Simulation/components/ModelPanel.vue
+++ b/client/src/views/Simulation/components/ModelPanel.vue
@@ -12,7 +12,7 @@
         </button>
       </aside>
     </settings-bar>
-    <global-graph v-if="model" :data="graph" :highlighted-nodes="editedNodes" @node-dblclick="onNodeClick"/>
+    <global-graph v-if="model" :data="graph" :edited-nodes="editedNodes" @node-dblclick="onNodeClick"/>
   </section>
 </template>
 


### PR DESCRIPTION
**What**

- Clean up of unused colors and node types in `encodings.ts`
- Visual distinction between variable nodes (solid outline) and non-variable nodes (dashed outline)
- Visual distinction of initial conditions (ellipse)
- Added control for boxes so it is clearer they can be collapsed and expanded.
- Added marker for nodes added to the Parameters panel in the Simulation view (instead of using color)
- Removed unused code for tooltips.

**Testing**

- Open any of the models in the Models view (note that the current SIR PNC doesn't include any metadata, that's why nodes are dashed, we need to switch to use the right SIR PNC with actual metadata)

https://user-images.githubusercontent.com/10552785/127361364-377183ce-39ff-4351-944f-fbdbd03c0203.mov


https://user-images.githubusercontent.com/10552785/127361375-2e18ed4f-8db0-4e7e-83f4-4b079445c0e8.mov


