### PR TITLE
Use aske-id data in models view to populate knowlege drilldown panel with cosmos data

### DIFF
--- a/client/src/types/typesCosmos.ts
+++ b/client/src/types/typesCosmos.ts
@@ -43,9 +43,10 @@ export interface CosmosSearchObjectsInterface {
 export interface CosmosSearchInterface {
   /** Cosmos API version */
   v: string;
-  total: number;
-  page: number;
-  objects: CosmosSearchObjectsInterface[];
+  total?: number;
+  page?: number;
+  objects?: CosmosSearchObjectsInterface[];
+  error?: string,
 }
 
 export interface CosmosArtifactObjectInterface {

--- a/client/src/types/typesGroMEt.ts
+++ b/client/src/types/typesGroMEt.ts
@@ -44,8 +44,8 @@ export interface ModelInterface extends Metadata {
 }
 
 export interface CodeCollectionInterface extends Metadata {
-  fileIds: FileId[],
-  globalReferenceId: {id: string, type: string},
+  file_ids: FileId[],
+  global_reference_id: {id: string, type: string},
 }
 
 export interface CodeSpanReference extends Metadata {

--- a/client/src/utils/CosmosDataUtil.ts
+++ b/client/src/utils/CosmosDataUtil.ts
@@ -8,6 +8,9 @@ export const filterToParamObj = (filterObj: {[key: string]: any}): any => {
   if (!_.isEmpty(filterObj.cosmosQuery)) {
     output.query = filterObj.cosmosQuery;
   }
+  if (!_.isEmpty(filterObj.askeId)) {
+    output.aske_id = filterObj.askeId;
+  }
   if (!_.isEmpty(filterObj.cosmosType)) {
     output.type = filterObj.cosmosType.map(type => COSMOS_TYPE_OPTIONS[type]);
   }

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -352,13 +352,15 @@
 
     async getDrilldownKnowledge (): Promise<void> {
       try {
-        const codeCollection = this.selectedGraphMetadata
-          .find(metadata => metadata.metadata_type === GroMEt.MetadataType.CodeCollectionReference);
+        if (this.selectedGraphMetadata?.constructor === Array) {
+          const codeCollection = this.selectedGraphMetadata
+            .find(metadata => metadata.metadata_type === GroMEt.MetadataType.CodeCollectionReference);
 
-        const response = await cosmosSearch(filterToParamObj({
-          askeId: (codeCollection as GroMEt.CodeCollectionInterface).global_reference_id.id,
-        }));
-        this.drilldownKnowledge = response;
+          const response = await cosmosSearch(filterToParamObj({
+            askeId: (codeCollection as GroMEt.CodeCollectionInterface).global_reference_id.id,
+          }));
+          this.drilldownKnowledge = response;
+        }
       } catch (e) {
         throw Error(e);
       }

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -122,6 +122,7 @@
   import { TabInterface, ViewInterface } from '@/types/types';
   import { GraphInterface, GraphLayoutInterface, GraphNodeInterface, SubgraphInterface, GraphLayoutInterfaceType } from '@/types/typesGraphs';
   import * as Model from '@/types/typesModel';
+  import * as GroMEt from '@/types/typesGroMEt';
   import { CosmosSearchInterface } from '@/types/typesCosmos';
   import { cosmosArtifactSrc, cosmosSearch, cosmosRelatedParameters } from '@/services/CosmosFetchService';
   import { filterToParamObj } from '@/utils/CosmosDataUtil';
@@ -349,9 +350,14 @@
       this.selectedLayoutId = layoutId;
     }
 
-    async searchCosmos (keyword: string): Promise<void> {
+    async getDrilldownKnowledge (): Promise<void> {
       try {
-        const response = await cosmosSearch(filterToParamObj({ cosmosQuery: [keyword] }));
+        const codeCollection = this.selectedGraphMetadata
+          .find(metadata => metadata.metadata_type === GroMEt.MetadataType.CodeCollectionReference);
+
+        const response = await cosmosSearch(filterToParamObj({
+          askeId: (codeCollection as GroMEt.CodeCollectionInterface).global_reference_id.id,
+        }));
         this.drilldownKnowledge = response;
       } catch (e) {
         throw Error(e);
@@ -369,6 +375,7 @@
       this.drilldownPaneTitle = node.label;
       this.drilldownPaneSubtitle = `${node.nodeType} (${node.dataType})`;
       this.drilldownMetadata = node.metadata;
+      this.getDrilldownKnowledge();
     }
 
     onBackgroundClick ():void {

--- a/client/src/views/Models/components/DrilldownPanel/KnowledgePane.vue
+++ b/client/src/views/Models/components/DrilldownPanel/KnowledgePane.vue
@@ -33,7 +33,7 @@
     dataLoading = false;
 
     get isEmptyData (): boolean {
-      return _.isEmpty(this.data);
+      return _.isEmpty(this.data) || Boolean(this.data.error);
     }
 
     showMoreHandler (doi: string): void {


### PR DESCRIPTION
note, when testing i noticed that xdd does not seem to have the aske-ids given by the grfn metadata in their system