### PR TITLE
Removed pointer from control for container nodes

### DIFF
--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -130,7 +130,7 @@ export default class EpiRenderer extends SVGRenderer {
           .style('stroke', DEFAULT_STYLE.node.stroke)
           .style('stroke-width', EpiRenderer.calcNodeStrokeWidth)
           .style('stroke-dasharray', EpiRenderer.calcNodeStrokeStyle)
-          .style('cursor', d => (d as any).nodes ? '' : 'pointer');
+          .style('cursor', 'pointer');
       } else {
         selection.append('ellipse')
           .attr('cx', d => (d as any).width * 0.5)
@@ -146,7 +146,7 @@ export default class EpiRenderer extends SVGRenderer {
 
       // Add +/- icon to boxes/containers
       if ((datum as any).nodes) {
-        const containerControl = selection.append('g').classed('container-control', true).style('cursor', 'pointer');
+        const containerControl = selection.append('g').classed('container-control', true);
 
         containerControl.append('rect')
           .attr('x', d => (d as any).width - 20)


### PR DESCRIPTION
**What**

- Removed pointer from the control added to collapsible nodes (container nodes). The container itself allows expanding and collapsing already so the pointer in the control is unneeded.
- Added the pointer to the container nodes so it is clearer that they can be collapsed and expanded.

**Testing**

- Select a model
- Try to expand and collapse container nodes. A cursor should show up for them but not for the control.

https://user-images.githubusercontent.com/10552785/127851722-ae34f01d-1f69-490a-84bc-eb16a838753b.mov

