### PR TITLE
Coordination between panels in the Simulation space

### DIFF
--- a/client/src/views/Simulation/Simulation.vue
+++ b/client/src/views/Simulation/Simulation.vue
@@ -73,7 +73,7 @@
           :key="index"
           :modelId="model.id"
           :slot="('parameters_' + model.id)"
-          :highlight="highlighted"
+          :highlighted="highlighted"
           @expand="setExpandedId('parameters')"
         />
         <variables-panel
@@ -82,6 +82,7 @@
           :key="index"
           :modelId="model.id"
           :slot="('variables_' + model.id)"
+          :highlighted="highlighted"
           @expand="setExpandedId('variables')"
         />
       </template>

--- a/client/src/views/Simulation/Simulation.vue
+++ b/client/src/views/Simulation/Simulation.vue
@@ -64,6 +64,7 @@
           :key="index"
           :model="model"
           :slot="('model_' + model.id)"
+          @highlight="onNodeHighlight"
           @expand="setExpandedId('model')"
         />
         <parameters-panel
@@ -72,6 +73,7 @@
           :key="index"
           :modelId="model.id"
           :slot="('parameters_' + model.id)"
+          :highlight="highlighted"
           @expand="setExpandedId('parameters')"
         />
         <variables-panel
@@ -128,6 +130,7 @@
     expandedId: string = '';
     runConfig: Donu.RequestConfig = { end: 120, start: 0, step: 30 };
     subgraph: Graph.GraphInterface = null;
+    highlighted: string = '';
 
     @Action fetchModelResults;
     @Action incrNumberOfSavedRuns;
@@ -277,6 +280,10 @@
           this.fetchModelResults({ model, config, selectedModelGraphType });
         });
       }
+    }
+
+    onNodeHighlight(label: string): void {
+      this.highlighted = label;
     }
   }
 </script>

--- a/client/src/views/Simulation/Simulation.vue
+++ b/client/src/views/Simulation/Simulation.vue
@@ -283,7 +283,7 @@
       }
     }
 
-    onNodeHighlight(label: string): void {
+    onNodeHighlight (label: string): void {
       this.highlighted = label;
     }
   }

--- a/client/src/views/Simulation/components/ModelPanel.vue
+++ b/client/src/views/Simulation/components/ModelPanel.vue
@@ -53,12 +53,14 @@
 
     settingsOpen: boolean = false;
 
-    onNodeClick(selected: Graph.GraphNodeInterface): void {
+    onNodeClick (selected: Graph.GraphNodeInterface): void {
       this.$emit('highlight', selected.label);
     }
-    onBackgroundClick(): void {
+
+    onBackgroundClick (): void {
       this.$emit('highlight', '');
     }
+
     onNodeDblClick (selected: Graph.GraphNodeInterface): void {
       this.toggleParameter({ modelId: this.model.id, selector: selected.label });
       this.toggleVariable({ modelId: this.model.id, selector: selected.label });

--- a/client/src/views/Simulation/components/ModelPanel.vue
+++ b/client/src/views/Simulation/components/ModelPanel.vue
@@ -16,6 +16,8 @@
       v-if="graph"
       :data="graph"
       :edited-nodes="editedNodes"
+      @node-click="onNodeClick"
+      @background-click="onBackgroundClick"
       @node-dblclick="onNodeDblClick"
     />
   </section>
@@ -51,6 +53,12 @@
 
     settingsOpen: boolean = false;
 
+    onNodeClick(selected: Graph.GraphNodeInterface): void {
+      this.$emit('highlight', selected.label);
+    }
+    onBackgroundClick(): void {
+      this.$emit('highlight', '');
+    }
     onNodeDblClick (selected: Graph.GraphNodeInterface): void {
       this.toggleParameter({ modelId: this.model.id, selector: selected.label });
       this.toggleVariable({ modelId: this.model.id, selector: selected.label });

--- a/client/src/views/Simulation/components/ParametersPanel.vue
+++ b/client/src/views/Simulation/components/ParametersPanel.vue
@@ -59,7 +59,7 @@
           class="parameter"
           v-for="(parameter, index) of displayedParameters"
           :key="index"
-          :class="[{ hidden: parameter.hidden, highlighted: parameter.metadata.name === highlighted }]"
+          :class="{ hidden: parameter.hidden, highlighted: parameter.metadata.name === highlighted }"
         >
           <h4 :title="parameter.metadata.name">{{ parameter.metadata.name }}</h4>
           <input type="text" v-model.number="parameterValues[parameter.uid]" />

--- a/client/src/views/Simulation/components/ParametersPanel.vue
+++ b/client/src/views/Simulation/components/ParametersPanel.vue
@@ -59,7 +59,7 @@
           class="parameter"
           v-for="(parameter, index) of displayedParameters"
           :key="index"
-          :class="{ hidden: parameter.hidden }"
+          :class="[{ hidden: parameter.hidden, highlighted: parameter.metadata.name === highlight }]"
         >
           <h4 :title="parameter.metadata.name">{{ parameter.metadata.name }}</h4>
           <input type="text" v-model.number="parameterValues[parameter.uid]" />
@@ -103,6 +103,7 @@
   export default class ParametersPanel extends Vue {
     @Prop({ default: false }) expanded: boolean;
     @Prop({ default: null }) modelId: number;
+    @Prop({ default: '' }) highlight: string;
     @InjectReactive() resized!: boolean;
     @InjectReactive() isResizing!: boolean;
 
@@ -402,6 +403,10 @@
 
   .parameter.hidden {
     opacity: 0.5;
+  }
+
+  .parameter.highlighted {
+    border: 1px var(--selection) solid;
   }
 </style>
 <style>

--- a/client/src/views/Simulation/components/ParametersPanel.vue
+++ b/client/src/views/Simulation/components/ParametersPanel.vue
@@ -59,7 +59,7 @@
           class="parameter"
           v-for="(parameter, index) of displayedParameters"
           :key="index"
-          :class="[{ hidden: parameter.hidden, highlighted: parameter.metadata.name === highlight }]"
+          :class="[{ hidden: parameter.hidden, highlighted: parameter.metadata.name === highlighted }]"
         >
           <h4 :title="parameter.metadata.name">{{ parameter.metadata.name }}</h4>
           <input type="text" v-model.number="parameterValues[parameter.uid]" />
@@ -103,7 +103,7 @@
   export default class ParametersPanel extends Vue {
     @Prop({ default: false }) expanded: boolean;
     @Prop({ default: null }) modelId: number;
-    @Prop({ default: '' }) highlight: string;
+    @Prop({ default: '' }) highlighted: string;
     @InjectReactive() resized!: boolean;
     @InjectReactive() isResizing!: boolean;
 

--- a/client/src/views/Simulation/components/ParametersPanel.vue
+++ b/client/src/views/Simulation/components/ParametersPanel.vue
@@ -103,7 +103,7 @@
   export default class ParametersPanel extends Vue {
     @Prop({ default: false }) expanded: boolean;
     @Prop({ default: null }) modelId: number;
-    @Prop({ default: '' }) highlighted: string;
+    @Prop({ default: null }) highlighted: string;
     @InjectReactive() resized!: boolean;
     @InjectReactive() isResizing!: boolean;
 
@@ -364,6 +364,7 @@
     grid-template-rows: 1fr 1fr;
     height: var(--parameter-height);
     padding: var(--padding);
+    border: 1px solid transparent;
   }
 
   .parameter:last-of-type {
@@ -406,7 +407,7 @@
   }
 
   .parameter.highlighted {
-    border: 1px var(--selection) solid;
+    border-color: var(--selection);
   }
 </style>
 <style>

--- a/client/src/views/Simulation/components/VariablesPanel.vue
+++ b/client/src/views/Simulation/components/VariablesPanel.vue
@@ -56,7 +56,7 @@
         <multi-line-plot
           v-else
           v-for="(plot, index) in displayedVariables"
-          class="pt-2 pl-2 pr-3"
+          class="pt-2 pl-2 pr-3 plot"
           :class="[{highlighted: plot.metadata.name === highlighted}]"
           :data="plot.values"
           :key="index"
@@ -155,7 +155,7 @@
   export default class VariablesPanel extends Vue {
     @Prop({ default: false }) expanded: boolean;
     @Prop({ default: null }) modelId: number;
-    @Prop({ default: '' }) highlighted: string;
+    @Prop({ default: null }) highlighted: string;
     @InjectReactive() resized!: boolean;
 
     @Getter getSimModel;
@@ -241,7 +241,10 @@
     margin-right: 1rem;
   }
 
-  .highlighted {
-    border: 1px var(--selection) solid;
+  .plot {
+    border: 1px solid transparent;
+  }
+  .plot.highlighted {
+    border-color: var(--selection);
   }
 </style>

--- a/client/src/views/Simulation/components/VariablesPanel.vue
+++ b/client/src/views/Simulation/components/VariablesPanel.vue
@@ -56,7 +56,8 @@
         <multi-line-plot
           v-else
           v-for="(plot, index) in displayedVariables"
-          :class="`pt-2 pl-2 pr-3 variable ${plot.hidden ? 'hidden' : ''}`"
+          class="pt-2 pl-2 pr-3"
+          :class="[{highlighted: plot.metadata.name === highlighted}]"
           :data="plot.values"
           :key="index"
           :styles="plot.styles"
@@ -154,6 +155,7 @@
   export default class VariablesPanel extends Vue {
     @Prop({ default: false }) expanded: boolean;
     @Prop({ default: null }) modelId: number;
+    @Prop({ default: '' }) highlighted: string;
     @InjectReactive() resized!: boolean;
 
     @Getter getSimModel;
@@ -228,10 +230,6 @@
     grid-area: action;
   }
 
-  .variable.hidden {
-    opacity: 0.5;
-  }
-
   .btn-settings {
     height: 25px;
     line-height: 0;
@@ -243,7 +241,7 @@
     margin-right: 1rem;
   }
 
-  .chart {
-    height: auto;
+  .highlighted {
+    border: 1px var(--selection) solid;
   }
 </style>


### PR DESCRIPTION
**What**
- Added coordinated highlighting from Models panel to Vars/Params panel.

**How**
- Added border for parameters and variables containers if they have the same name than the selected node in the Model panel. Ideally, this should use the `uid` but it doesn't seem to match. NOTE: We probably want to double check that in the parser and adapt it. 

**Testing**

- Select a model and open the simulation view
- Add parameters and run the model.
- Select nodes from the Model visualization. The corresponding containers in the params/variable panels should get highlighted.

https://user-images.githubusercontent.com/10552785/127869001-fd07e022-c4de-45ff-b03b-2fd17c040560.mov


