### PR TITLE
Ability to show metadata for PNC EMMAA GroMEts

### DIFF
--- a/client/src/types/typesGroMEt.ts
+++ b/client/src/types/typesGroMEt.ts
@@ -101,8 +101,6 @@ export interface TextParameter extends Metadata {
   value: string,
 }
 
-
-
 export interface IndraAgentReferenceSet extends Metadata {
   indra_agent_references: IndraAgentReference[],
 }

--- a/client/src/types/typesGroMEt.ts
+++ b/client/src/types/typesGroMEt.ts
@@ -16,6 +16,11 @@ type FileId = {
   uid: string,
 }
 
+type IndraAgentReference = {
+  db_refs: Record<string, string>,
+  name: string,
+};
+
 export enum CodeType {
   CodeBlock = 'CODE_BLOCK',
   Identifier = 'IDENTIFIER',
@@ -29,6 +34,8 @@ export enum MetadataType {
   TextDefinition = 'TextDefinition',
   TextParameter = 'TextParameter',
   TextualDocumentReferenceSet = 'TextualDocumentReferenceSet',
+  IndraAgentReferenceSet = 'IndraAgentReferenceSet',
+  ReactionReference = 'ReactionReference',
 }
 
 export interface Metadata {
@@ -92,4 +99,15 @@ export interface TextParameter extends Metadata {
   },
   variable_identifier: string,
   value: string,
+}
+
+
+
+export interface IndraAgentReferenceSet extends Metadata {
+  indra_agent_references: IndraAgentReference[],
+}
+
+export interface ReactionReference extends Metadata {
+  reaction_rule: string,
+  indra_stmt_hash: string,
 }

--- a/client/src/types/typesGroMEt.ts
+++ b/client/src/types/typesGroMEt.ts
@@ -107,5 +107,6 @@ export interface IndraAgentReferenceSet extends Metadata {
 
 export interface ReactionReference extends Metadata {
   reaction_rule: string,
-  indra_stmt_hash: string,
+  indra_stmt_hash: number,
+  is_reverse: false,
 }

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -382,11 +382,10 @@
       this.drilldownMetadata = node.metadata ? node.metadata.flat() : null;
 
       // Select tab to open
-      this.drilldownActiveTabId = this.drilldownMetadata.metadata_type === GroMEt.MetadataType.ReactionReference ? 'knowledge' : 'metadata';
-
+      // this.drilldownActiveTabId = this.drilldownMetadata[0].metadata_type === GroMEt.MetadataType.ReactionReference ? 'knowledge' : 'metadata';
       this.drilldownPaneSubtitle = `${node.nodeType} (${node.dataType})`;
       this.drilldownPaneTitle = node.label;
-      this.getDrilldownKnowledge();
+      // this.getDrilldownKnowledge();
     }
 
     onBackgroundClick ():void {

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -79,6 +79,7 @@
         v-if="drilldownActiveTabId === 'metadata' && drilldownMetadata"
         slot="content"
         :metadata="drilldownMetadata"
+        :model-name="selectedModel.name"
         @open-modal="onOpenModalMetadata"
       />
       <parameters-pane
@@ -381,11 +382,9 @@
       // Merge node metadata with Variables metadata. c.f. GraphNodeInterface type
       this.drilldownMetadata = node.metadata ? node.metadata.flat() : null;
 
-      // Select tab to open
-      // this.drilldownActiveTabId = this.drilldownMetadata[0].metadata_type === GroMEt.MetadataType.ReactionReference ? 'knowledge' : 'metadata';
       this.drilldownPaneSubtitle = `${node.nodeType} (${node.dataType})`;
       this.drilldownPaneTitle = node.label;
-      // this.getDrilldownKnowledge();
+      this.getDrilldownKnowledge();
     }
 
     onBackgroundClick ():void {

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -365,6 +365,7 @@
             }));
           }
         }
+
       } catch (e) {
         throw Error(e);
       }
@@ -376,12 +377,13 @@
     }
 
     onNodeClick (node: GraphNodeInterface): void {
-      // Select which tab should be open first, then open the drilldown.
-      this.drilldownActiveTabId = 'metadata';
       this.isOpenDrilldown = true;
 
       // Merge node metadata with Variables metadata. c.f. GraphNodeInterface type
       this.drilldownMetadata = node.metadata ? node.metadata.flat() : null;
+
+      // Select tab to open
+      this.drilldownActiveTabId = this.drilldownMetadata.metadata_type === GroMEt.MetadataType.ReactionReference ? 'knowledge' : 'metadata';
 
       this.drilldownPaneSubtitle = `${node.nodeType} (${node.dataType})`;
       this.drilldownPaneTitle = node.label;

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -377,6 +377,8 @@
     }
 
     onNodeClick (node: GraphNodeInterface): void {
+      // Select which tab should be open first, then open the drilldown.
+      this.drilldownActiveTabId = 'metadata';
       this.isOpenDrilldown = true;
 
       // Merge node metadata with Variables metadata. c.f. GraphNodeInterface type

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -365,7 +365,6 @@
             }));
           }
         }
-
       } catch (e) {
         throw Error(e);
       }

--- a/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
+++ b/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
@@ -90,14 +90,12 @@
             <details v-if="hasNodeEvidences" class="metadata" open>
               <summary>Evidence ({{nodeEvidences.length}})</summary>
               <div class="metadata-content">
-                <div class="metadata-content">
                   <figure
                     v-for="(nodeEvidence, index) in nodeEvidences"
                     :key="index"
                   >
                     {{ excerpt(nodeEvidence) }}
                   </figure>
-                </div>
               </div>
             </details>
       </template>
@@ -134,7 +132,6 @@
     GroMET.MetadataType.TextParameter,
     GroMET.MetadataType.EquationDefinition,
     GroMET.MetadataType.CodeSpanReference,
-    GroMET.MetadataType.CodeSpanReference,
     GroMET.MetadataType.IndraAgentReferenceSet,
     GroMET.MetadataType.ReactionReference,
   ];
@@ -154,10 +151,11 @@
     nodeEvidences: EMMAA.EmmaaEvidenceEvidenceInterface[] = [];
 
     @Watch('metadata') onDataChange (): void {
-      if (this.metadata.find(datum => datum.metadata_type === GroMET.MetadataType.IndraAgentReferenceSet)) {
+
+      if (this.metadata.find(this.isTypeIndraAgentReferenceSet)) {
         this.fetchAgentsReferences();
       }
-      if (this.metadata.find(datum => datum.metadata_type === GroMET.MetadataType.ReactionReference)) {
+      if (this.metadata.find(this.isTypeReactionReference)) {
         this.fetchNodeEvidences();
       }
     }
@@ -172,7 +170,7 @@
     }
 
     get hasNodeEvidences (): boolean {
-      return this.nodeEvidences.length > 0;
+      return this.nodeEvidences.length > 0 ?? this.nodeEvidences === [];
     }
 
     get sortedMetadata (): GroMET.Metadata[] {

--- a/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
+++ b/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
@@ -87,17 +87,27 @@
 
       <template v-if="isTypeReactionReference(datum)">
         <summary :title="datum.uid">Reaction Reference(s)</summary>
-            <details v-if="hasNodeEvidences" class="metadata" open>
-              <summary>Evidence ({{nodeEvidences.length}})</summary>
-              <div class="metadata-content">
-                  <figure
-                    v-for="(nodeEvidence, index) in nodeEvidences"
-                    :key="index"
-                  >
-                    {{ excerpt(nodeEvidence) }}
-                  </figure>
-              </div>
-            </details>
+        <div class="metadata-content">
+          <template v-if="nodeStatement.type">
+            <h6>Type</h6>
+            <p>{{ nodeStatement.type }}</p>
+          </template>
+          <template v-if="nodeStatement.belief">
+            <h6>Belief score</h6>
+            <p>{{ nodeStatement.belief }}</p>
+          </template>
+          <deta ils v-if="nodeStatement" class="metadata" open>
+            <summary v-if="nodeStatement.evidence">Evidence ({{nodeStatement.evidence.length}})</summary>
+            <div class="metadata-content">
+              <figure
+                v-for="(evidence, index) in nodeStatement.evidence"
+                :key="index"
+              >
+                {{ excerpt(evidence) }}
+              </figure>
+            </div>
+          </details>
+        </div>
       </template>
 
       <aside class="metadata-provenance">
@@ -148,10 +158,9 @@
 
     isLoading = false;
     agentsReferences: EMMAA.EmmaaEntityInfoInterface[] = [];
-    nodeEvidences: EMMAA.EmmaaEvidenceEvidenceInterface[] = [];
+    nodeStatement: EMMAA.EmmaaEvidenceInterface = null;
 
     @Watch('metadata') onDataChange (): void {
-
       if (this.metadata.find(this.isTypeIndraAgentReferenceSet)) {
         this.fetchAgentsReferences();
       }
@@ -169,9 +178,9 @@
       }
     }
 
-    get hasNodeEvidences (): boolean {
-      return this.nodeEvidences?.length > 0 || this.nodeEvidences === [];
-    }
+    // get hasNodeStatement (): boolean {
+    //   return this.nodeStatement;
+    // }
 
     get sortedMetadata (): GroMET.Metadata[] {
       return [...this.metadata].sort((a, b) => {
@@ -239,14 +248,13 @@
       this.isLoading = true;
 
       const statementId = (this.metadata[0] as GroMET.ReactionReference).indra_stmt_hash;
-      const resultEmmaaEvidence = await emmaaEvidence({
+      this.nodeStatement = await emmaaEvidence({
         stmt_hash: Number(statementId),
         source: 'model_statement',
         model: this.modelName,
         format: 'json',
       });
 
-      this.nodeEvidences = resultEmmaaEvidence.evidence;
       this.isLoading = false;
     }
 

--- a/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
+++ b/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
@@ -170,7 +170,7 @@
     }
 
     get hasNodeEvidences (): boolean {
-      return this.nodeEvidences.length > 0 ?? this.nodeEvidences === [];
+      return this.nodeEvidences?.length > 0 || this.nodeEvidences === [];
     }
 
     get sortedMetadata (): GroMET.Metadata[] {
@@ -228,7 +228,7 @@
 
       this.agentsReferences = await Promise.all((this.metadata[0] as GroMET.IndraAgentReferenceSet)
        .indra_agent_references.map(async (reference) => {
-        const args = { modelName: null, namespace: Object.keys(reference.db_refs)[0], id: Object.values(reference.db_refs)[0] };
+        const args = { modelName: this.modelName, namespace: Object.keys(reference.db_refs)[0], id: Object.values(reference.db_refs)[0] };
         const response = await emmaaEntityInfo(args as any);
          return response;
         }));

--- a/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
+++ b/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
@@ -70,10 +70,10 @@
         <summary :title="datum.uid">Agent(s) Reference(s)</summary>
         <div class="metadata-content"  v-for="(entity, index) in emmaaInfo" :key="index">
            <details v-if="entity.definition" class="metadata" open>
-            <summary>Definition 
-              (<a v-if="entity.url" :href="entity.url">
-              {{ entity.name }}
-              </a>)
+            <summary>Definition
+              <a v-if="entity.url" :href="entity.url">
+              ({{ entity.name }})
+              </a>
             </summary>
             <div class="metadata-content">
               <p>{{ entity.definition }}</p>
@@ -119,12 +119,6 @@
     MessageDisplay,
     LoadingAlert,
   };
-
-  const emptyEmmaaInfo = {
-    definition: null,
-    name: null,
-    url: null,
-  } as EmmaaEntityInfoInterface;
 
   @Component({ components })
   export default class MetadataPane extends Vue {
@@ -196,12 +190,11 @@
 
        this.emmaaInfo = await Promise.all((this.metadata[0] as GroMET.IndraAgentReferenceSet)
        .indra_agent_references.map(async (reference) => {
-        const args = { modelName: null, namespace: Object.keys(reference.db_refs)[0], id:  Object.values(reference.db_refs)[0]};
+        const args = { modelName: null, namespace: Object.keys(reference.db_refs)[0], id: Object.values(reference.db_refs)[0] };
         const response = await emmaaEntityInfo(args as any);
          return response;
         }));
       this.isLoading = false;
-
     }
 
     sourceFilePosition (datum: GroMET.CodeSpanReference): string {
@@ -255,6 +248,5 @@
       const regex = /(<math).*?(<\/math>)/g;
       return regex.exec(mml)[0] ?? null;
     }
-
   }
 </script>

--- a/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
+++ b/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
@@ -96,7 +96,7 @@
             <h6>Belief score</h6>
             <p>{{ nodeStatement.belief }}</p>
           </template>
-          <deta ils v-if="nodeStatement" class="metadata" open>
+          <details v-if="nodeStatement" class="metadata" open>
             <summary v-if="nodeStatement.evidence">Evidence ({{nodeStatement.evidence.length}})</summary>
             <div class="metadata-content">
               <figure
@@ -170,17 +170,13 @@
     }
 
     mounted (): void {
-      if (this.metadata.find(datum => datum.metadata_type === GroMET.MetadataType.IndraAgentReferenceSet)) {
+      if (this.metadata.find(this.isTypeIndraAgentReferenceSet)) {
         this.fetchAgentsReferences();
       }
-      if (this.metadata.find(datum => datum.metadata_type === GroMET.MetadataType.ReactionReference)) {
+      if (this.metadata.find(this.isTypeReactionReference)) {
         this.fetchNodeEvidences();
       }
     }
-
-    // get hasNodeStatement (): boolean {
-    //   return this.nodeStatement;
-    // }
 
     get sortedMetadata (): GroMET.Metadata[] {
       return [...this.metadata].sort((a, b) => {
@@ -191,7 +187,7 @@
     }
 
     get isEmptyMetadata (): boolean {
-      return this.metadata.length === 0;
+      return this.metadata?.length === 0 || this.metadata === [];
     }
 
     isTypeCodeSpanReference (datum: GroMET.Metadata): boolean {

--- a/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
+++ b/client/src/views/Models/components/DrilldownPanel/MetadataPane.vue
@@ -68,15 +68,18 @@
 
       <template v-if="isTypeIndraAgentReferenceSet(datum)">
         <summary :title="datum.uid">Agent(s) Reference(s)</summary>
-        <div class="metadata-content"  v-for="(entity, index) in emmaaInfo" :key="index">
-           <details v-if="entity.definition" class="metadata" open>
-            <summary>Definition
-              <a v-if="entity.url" :href="entity.url">
-              ({{ entity.name }})
+        <div class="metadata-content"  v-for="(reference, index) in agentsReferences" :key="index">
+           <details class="metadata" open>
+            <summary>
+              <a v-if="reference.url" :href="reference.url">
+              {{ reference.name }}
               </a>
             </summary>
-            <div class="metadata-content">
-              <p>{{ entity.definition }}</p>
+            <div v-if="reference.definition" class="metadata-content">
+              <p>{{ reference.definition }}</p>
+            </div>
+            <div v-else class="metadata-content">
+              No definition.
             </div>
           </details>
         </div>
@@ -125,17 +128,17 @@
     @Prop({ default: [] }) metadata: GroMET.Metadata[];
 
     isLoading = false;
-    emmaaInfo: EmmaaEntityInfoInterface[] = [];
+    agentsReferences: EmmaaEntityInfoInterface[] = [];
 
     @Watch('metadata') onDataChange (): void {
-      if (this.isTypeIndraAgentReferenceSet) {
-        this.fetchExternalData();
+      if (this.metadata.find(datum => datum.metadata_type === GroMET.MetadataType.IndraAgentReferenceSet)) {
+        this.fetchAgentsReferences();
       }
     }
 
     mounted (): void {
-      if (this.isTypeIndraAgentReferenceSet) {
-        this.fetchExternalData();
+      if (this.metadata.find(datum => datum.metadata_type === GroMET.MetadataType.IndraAgentReferenceSet)) {
+        this.fetchAgentsReferences();
       }
     }
 
@@ -184,16 +187,17 @@
       this.$emit('open-modal', doi);
     }
 
-    async fetchExternalData (): Promise<void> {
+    async fetchAgentsReferences (): Promise<void> {
       this.isLoading = true;
-      this.emmaaInfo = [];
+      this.agentsReferences = [];
 
-       this.emmaaInfo = await Promise.all((this.metadata[0] as GroMET.IndraAgentReferenceSet)
+      this.agentsReferences = await Promise.all((this.metadata[0] as GroMET.IndraAgentReferenceSet)
        .indra_agent_references.map(async (reference) => {
         const args = { modelName: null, namespace: Object.keys(reference.db_refs)[0], id: Object.values(reference.db_refs)[0] };
         const response = await emmaaEntityInfo(args as any);
          return response;
         }));
+      console.log(this.agentsReferences);
       this.isLoading = false;
     }
 


### PR DESCRIPTION
**What**

- Added two additional types of metadata included in PNC EMMAA GroMETs (`IndraAgentReferenceSet` and `ReactionReference`)
- Using this metadata, we enable the ability to get agent references and pieces of evidence from EMMAA (similarly to how we do it for the Graphs).

**Testing**
- Select one of the two EMMAA gromets (MARM model or RAS model).I'd highly recommend you to test this out using the MARM model since the current RAS model is too big.
- Select a node from the model (edges don't include metadata for gromets)

![image](https://user-images.githubusercontent.com/10552785/128265296-29db3ff2-676d-4fe8-8846-7869d4e2ee58.png)
![image](https://user-images.githubusercontent.com/10552785/128358129-60a4a529-d772-4076-852c-c760d2341673.png)


NOTES: Testing might be annoying because you need to use the current EMMAA GroMEt visualizations, which take some time to load and are basically a hard ball, which makes difficult to select things. I also noticed, we don't seem to be getting DOIs from the EMMAA evidence so I wasn't able to leverage COSMOS for that. I need to follow up with HMS. I also noticed a bunch of inconsistent CORS errors by using these EMMAA endpoints. Not sure what's going on there, maybe @mj3cheun would be able to help out with this.