### PR TITLE
[FEATURE] Add text search query to model's list view

### DIFF
--- a/client/src/components/Counters.vue
+++ b/client/src/components/Counters.vue
@@ -22,7 +22,7 @@
 
     get processedData () : string[] {
       return this.data.reduce((acc: string[], counter: Counter) => {
-        const value = counter.value ? shorterNb(Number(counter.value)) : NaN;
+        const value = counter.value != null ? shorterNb(Number(counter.value)) : NaN;
         if (Number.isNaN(value)) {
           acc.push(counter.name);
         } else if (counter.inverse) {

--- a/client/src/services/DonuService.ts
+++ b/client/src/services/DonuService.ts
@@ -75,6 +75,22 @@ const convertGrometEdgesDataToBGraphEdgesData = (edges: any[]): any[] => {
   return bgEdges;
 };
 
+/** Query available models from Donu API */
+export const queryDonuModels = async (text: string): Promise<any[]> => {
+  const request: Donu.Request = {
+    command: Donu.RequestCommand.QUERY_MODELS,
+    text,
+  };
+
+  const response = await callDonu(request);
+  if (response.status === Donu.ResponseStatus.success) {
+    const models = response.result ?? [];
+    return models;
+  } else {
+    console.error('[DONU Service] — queryDonuModels', response); // eslint-disable-line no-console
+  }
+};
+
 /** Fetch a complete list of available models from Donu API */
 export const fetchDonuModels = async (): Promise<Model.Model[]> => {
   const request: Donu.Request = {

--- a/client/src/services/DonuService.ts
+++ b/client/src/services/DonuService.ts
@@ -82,7 +82,7 @@ export const queryDonuModels = async (text: string): Promise<any[]> => {
     text,
   };
 
-  const response = await callDonu(request);
+  const response = await callDonuCache(request);
   if (response.status === Donu.ResponseStatus.success) {
     const models = response.result ?? [];
     return models;

--- a/client/src/types/typesDonu.ts
+++ b/client/src/types/typesDonu.ts
@@ -10,6 +10,7 @@ enum RequestCommand {
   // GET_MODEL_SCHEMATIC = 'get-model-schematic',
   GET_MODEL_SOURCE = 'get-model-source',
   LIST_MODELS = 'list-models',
+  QUERY_MODELS = 'query-models',
   SIMULATE = 'simulate',
   // UPLOAD_MODEL = 'upload-model',
 }
@@ -94,6 +95,7 @@ type Request = {
   start?: number;
   step?: number;
   'sim-type'?: SimulationType | void,
+  text?: string,
   // type?: string;
 }
 

--- a/client/src/utils/QueryFieldsUtil.ts
+++ b/client/src/utils/QueryFieldsUtil.ts
@@ -221,8 +221,8 @@ const QUERY_FIELDS_MAP: QueryFieldMap = {
   },
   // MODELS
   MODELS_TEXT_SEARCH: {
-    ..._field('modelsTextSearch', 'Text Search'),
-    ..._searchable('Text Search', false),
+    ..._field('modelsTextSearch', 'Keyword'),
+    ..._searchable('Keyword', false),
     baseType: 'string',
     lexType: 'string',
   },

--- a/client/src/utils/QueryFieldsUtil.ts
+++ b/client/src/utils/QueryFieldsUtil.ts
@@ -219,6 +219,13 @@ const QUERY_FIELDS_MAP: QueryFieldMap = {
     baseType: 'string',
     lexType: 'string',
   },
+  // MODELS
+  MODELS_TEXT_SEARCH: {
+    ..._field('modelsTextSearch', 'Text Search'),
+    ..._searchable('Text Search', false),
+    baseType: 'string',
+    lexType: 'string',
+  },
   // Placeholders for testing purposes
   HISTOGRAM: {
     ..._field('histogram', 'Histogram'),

--- a/client/src/views/Models/ModelsList.vue
+++ b/client/src/views/Models/ModelsList.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="view-container">
-    <loader v-if="modelsCards.length < 1" loading="true" />
-    <main v-else>
+    <main>
       <div class="search-row">
         <search-bar :pills="searchPills" :placeholder="`Search for Models...`"/>
       </div>
@@ -26,11 +25,12 @@
           </button>
         </div>
       </settings-bar>
-      <card-container
+      <card-container v-if="!dataLoading"
         class="models-cards"
         :cards="modelsCards"
         @click-card="onClickCard"
       />
+      <loader :loading="dataLoading" />
     </main>
   </div>
 </template>
@@ -38,17 +38,21 @@
 <script lang="ts">
   import Component from 'vue-class-component';
   import Vue from 'vue';
+  import { Watch } from 'vue-property-decorator';
   import { Action, Getter, Mutation } from 'vuex-class';
   import { RawLocation } from 'vue-router';
 
+  import { queryDonuModels } from '@/services/DonuService';
+
   import { CardInterface, Counter, TabInterface } from '@/types/types';
+  import { Filters } from '@/types/typesLex';
   import * as Model from '@/types/typesModel';
 
   import SearchBar from '@/components/SearchBar.vue';
   import Counters from '@/components/Counters.vue';
   import SettingsBar from '@/components/SettingsBar.vue';
   import Settings from './components/Settings.vue';
-  import RangePill from '@/search/pills/RangePill';
+  import TextPill from '@/search/pills/TextPill';
   import { QUERY_FIELDS_MAP } from '@/utils/QueryFieldsUtil';
 
   import LeftSidePanel from '@/components/LeftSidePanel.vue';
@@ -83,6 +87,9 @@
   export default class ModelsList extends Vue {
     tabs: TabInterface[] = TABS;
     activeTabId: string = 'facets';
+    allowModelSourceList: string[] = []; // Models that should not be filtered
+    dataLoading: boolean = true; // Toggles loading screen
+    models: Model.Model[] = [];
 
     @Action resetSelectedModelIds;
     @Getter getFilters;
@@ -90,17 +97,53 @@
     @Getter getSelectedModelIds;
     @Mutation setSelectedModels;
 
+    @Watch('getFilters') onGetFiltersChanged (newFilters: Filters): void {
+      this.handleFiltersChanged(newFilters);
+    }
+
+    @Watch('getModelsList') onGetModelsListChanged (): void {
+      this.setModels();
+    }
+
+    created (): void {
+      this.setModels();
+    }
+
     activated (): void {
       this.resetSelectedModelIds();
     }
 
-    get models (): Model.Model[] {
-      return this.getModelsList;
+    async handleFiltersChanged (newFilters: Filters): Promise<void> {
+      if (newFilters.clauses.length > 0) {
+        this.dataLoading = true;
+        const text = newFilters.clauses.find(clause => clause.field === QUERY_FIELDS_MAP.MODELS_TEXT_SEARCH.field)?.values[0] as string;
+        const models = await queryDonuModels(text);
+        this.allowModelSourceList = models.map(m => m.source.model);
+      }
+      this.setModels();
+    }
+
+    setModels (): void {
+      if (this.getModelsList.length === 0) {
+        // Models have not been loaded in store yet
+        this.models = [];
+      } else if (this.getModelsList.length > 0 && this.getFilters.clauses.length === 0) {
+        // No Query present: return full model list
+        this.models = this.getModelsList;
+        this.dataLoading = false;
+      } else {
+        // Query present: filter models based on model sources returned in query results
+        const models = this.getModelsList.filter(m => {
+          return m.modelGraph.find(d => this.allowModelSourceList.includes(d.model));
+        });
+        this.models = models;
+        this.dataLoading = false;
+      }
     }
 
     get searchPills (): any {
       return [
-        new RangePill(QUERY_FIELDS_MAP.HISTOGRAM),
+        new TextPill(QUERY_FIELDS_MAP.MODELS_TEXT_SEARCH),
       ];
     }
 


### PR DESCRIPTION
### Description
Add Donu text search capabilities to models list.

### Changes
- Add Donu `query-models` service
- Add model's text search query pill type
- Add Text Pill to models list search bar
- React to filter changes modifying model list

### Considerations
- Going back from Model Simulation view does not keep filters in search bar.
- Model querying is slow. This is on the Donu side and may be a result of inefficient regex search.
- Search results are not great when little metadata is present.

### Testing
- Regex search patterns can be used, ie. `*beta*`

### Artifacts:
![Screen Shot 2021-08-05 at 11 36 11 AM](https://user-images.githubusercontent.com/15199528/128379878-8b850776-2705-4ff4-ac98-4b45e830bb94.png)



