### PR TITLE
Consolidated fixes

### DIFF
--- a/client/src/components/Modals/ModalDocument.vue
+++ b/client/src/components/Modals/ModalDocument.vue
@@ -49,10 +49,10 @@
 
   import SimilarDocs from '@/components/SimilarDocs.vue';
   import Modal from '@/components/Modal.vue';
-  import { CardInterface } from '@/types/types';
   import {
     CosmosArtifactInterface,
     CosmosArtifactObjectInterface,
+    CosmosSearchObjectsInterface,
     CosmosSearchBibjsonInterface,
     CosmosSearchChildrenInterface,
   } from '@/types/typesCosmos';
@@ -65,7 +65,7 @@
 
   @Component({ components })
   export default class ModalDocument extends Vue {
-    @Prop({ required: false }) private data: CardInterface;
+    @Prop({ required: false }) private data: CosmosSearchObjectsInterface;
     @Prop({ required: false }) private artifact: CosmosArtifactInterface;
     @Prop({ default: false }) linkToKnowledgeSpace: boolean;
 
@@ -74,11 +74,11 @@
     }
 
     get bibjson (): CosmosSearchBibjsonInterface {
-      return this.artifact?.bibjson ?? this.data?.raw?.bibjson;
+      return this.artifact?.bibjson ?? this.data?.bibjson;
     }
 
     get children (): CosmosSearchChildrenInterface[] | CosmosArtifactObjectInterface[] {
-      return this.artifact?.objects ?? this.data?.raw.children ?? [];
+      return this.artifact?.objects ?? this.data?.children ?? [];
     }
 
     get doi (): string {
@@ -94,7 +94,7 @@
     }
 
     get title (): string {
-      return this.bibjson?.title ?? this.data?.title ?? '';
+      return this.bibjson?.title ?? '';
     }
 
     get excerpt (): string {
@@ -106,7 +106,7 @@
     }
 
     get imagePreview (): string {
-      return this.children?.[0]?.bytes ?? this.data?.previewImageSrc;
+      return this.children?.[0]?.bytes;
     }
 
     get imageStyle (): any {

--- a/client/src/components/Modals/ModalDocument.vue
+++ b/client/src/components/Modals/ModalDocument.vue
@@ -1,8 +1,15 @@
 <template>
   <modal @close="onClickClose">
-    <div slot="header">
-      <a :href="url" target="_blank"><h3>{{ title }}</h3></a>
-      <h5 class="m-0">{{ doi }}</h5>
+    <div class="flex-grow-1" slot="header">
+      <a :href="url" target="_blank">
+        <h3>{{ title }}</h3>
+      </a>
+      <div class="d-flex align-items-center justify-content-between">
+        <h5 class="m-0">{{ doi }}</h5>
+        <button class="btn btn-primary" @click="openKnowledgeView(true)">
+          Search Document Artifacts
+        </button>
+      </div>
     </div>
     <div slot="body" class="d-flex flex-column flex-grow-1">
       <div class="d-flex flex-grow-1">
@@ -43,8 +50,10 @@
   import Vue from 'vue';
   import Component from 'vue-class-component';
   import { Prop } from 'vue-property-decorator';
+  import { Action } from 'vuex-class';
 
   import { getAuthorList } from '@/utils/CosmosDataUtil';
+  import { addSearchTerm, newFilters } from '@/utils/FiltersUtil';
   import CloseButton from '@/components/widgets/CloseButton.vue';
 
   import SimilarDocs from '@/components/SimilarDocs.vue';
@@ -65,6 +74,8 @@
 
   @Component({ components })
   export default class ModalDocument extends Vue {
+    @Action setFilters;
+
     @Prop({ required: false }) private data: CosmosSearchObjectsInterface;
     @Prop({ required: false }) private artifact: CosmosArtifactInterface;
     @Prop({ default: false }) linkToKnowledgeSpace: boolean;
@@ -135,10 +146,16 @@
       e.stopPropagation();
     }
 
-    openKnowledgeView () : void {
+    openKnowledgeView (loadId: boolean) : void {
       const name = 'docsCards';
-      const args = this.doi ? { name, query: { doi: this.doi } } : { name };
+      const args = { name };
       this.$router.push(args);
+
+      if (loadId) {
+        const filters = newFilters();
+        addSearchTerm(filters, 'cosmosDoi', this.doi, 'or', false);
+        this.setFilters(filters);
+      }
     }
   }
 </script>

--- a/client/src/services/CosmosFetchService.ts
+++ b/client/src/services/CosmosFetchService.ts
@@ -50,7 +50,7 @@ export const cosmosArtifactSrc = (id: string): Promise<CosmosSearchInterface> =>
 const COSMOS_ARTIFACT_URL = `${COSMOS_API_URL_PREFIX}/sets/xdd-covid-19/cosmos/api/document`;
 
 // eslint-disable-next-line camelcase
-export const cosmosArtifactsMem = async (paramObj: {doi: string, image_type?: string}): Promise<CosmosArtifactInterface> => {
+export const cosmosArtifactsMem = async (paramObj: {doi?: string, aske_id?: string, image_type?: string}): Promise<CosmosArtifactInterface> => {
   const artifactList = await getUtilMem(COSMOS_ARTIFACT_URL, addCosmosAPIKey({ ...paramObj }));
   if (artifactList.objects) {
     artifactList.objects.map(async (artifact, index) =>

--- a/client/src/utils/CosmosDataUtil.ts
+++ b/client/src/utils/CosmosDataUtil.ts
@@ -8,6 +8,9 @@ export const filterToParamObj = (filterObj: {[key: string]: any}): any => {
   if (!_.isEmpty(filterObj.cosmosQuery)) {
     output.query = filterObj.cosmosQuery;
   }
+  if (!_.isEmpty(filterObj.cosmosDoi)) {
+    output.doi = filterObj.cosmosDoi;
+  }
   if (!_.isEmpty(filterObj.cosmosAskeId)) {
     output.aske_id = filterObj.cosmosAskeId;
   }

--- a/client/src/utils/CosmosDataUtil.ts
+++ b/client/src/utils/CosmosDataUtil.ts
@@ -3,6 +3,11 @@ import { COSMOS_TYPE_OPTIONS } from '@/utils/ModelTypeUtil';
 
 import { CosmosSearchBibjsonInterface } from '@/types/typesCosmos';
 
+export const ID_TYPE_MAP = {
+  aske_id: 'cosmosAskeId',
+  doi: 'cosmosDoi',
+};
+
 export const filterToParamObj = (filterObj: {[key: string]: any}): any => {
   const output: any = {};
   if (!_.isEmpty(filterObj.cosmosQuery)) {

--- a/client/src/utils/CosmosDataUtil.ts
+++ b/client/src/utils/CosmosDataUtil.ts
@@ -8,8 +8,8 @@ export const filterToParamObj = (filterObj: {[key: string]: any}): any => {
   if (!_.isEmpty(filterObj.cosmosQuery)) {
     output.query = filterObj.cosmosQuery;
   }
-  if (!_.isEmpty(filterObj.askeId)) {
-    output.aske_id = filterObj.askeId;
+  if (!_.isEmpty(filterObj.cosmosAskeId)) {
+    output.aske_id = filterObj.cosmosAskeId;
   }
   if (!_.isEmpty(filterObj.cosmosType)) {
     output.type = filterObj.cosmosType.map(type => COSMOS_TYPE_OPTIONS[type]);

--- a/client/src/utils/QueryFieldsUtil.ts
+++ b/client/src/utils/QueryFieldsUtil.ts
@@ -199,7 +199,12 @@ const QUERY_FIELDS_MAP: QueryFieldMap = {
     ..._searchable('ASKE ID', false),
     baseType: 'string',
     lexType: 'string',
-    order: 2,
+  },
+  COSMOS_DOI: {
+    ..._field('cosmosDoi', 'DOI'),
+    ..._searchable('DOI', false),
+    baseType: 'string',
+    lexType: 'string',
   },
   COSMOS_TYPE: {
     ..._field('cosmosType', 'Doc Artifact Type'),

--- a/client/src/utils/QueryFieldsUtil.ts
+++ b/client/src/utils/QueryFieldsUtil.ts
@@ -194,6 +194,13 @@ const QUERY_FIELDS_MAP: QueryFieldMap = {
     lexType: 'string',
     order: 2,
   },
+  COSMOS_ASKE_ID: {
+    ..._field('cosmosAskeId', 'ASKE ID'),
+    ..._searchable('ASKE ID', false),
+    baseType: 'string',
+    lexType: 'string',
+    order: 2,
+  },
   COSMOS_TYPE: {
     ..._field('cosmosType', 'Doc Artifact Type'),
     ..._searchable('Doc Artifact Type', false),

--- a/client/src/views/Knowledge/DocsCards/DocsCards.vue
+++ b/client/src/views/Knowledge/DocsCards/DocsCards.vue
@@ -26,7 +26,7 @@
     </drilldown-panel>
     <modal-document
       v-if="showModalDocuments"
-      :data="drilldownData"
+      :data="drilldownData.raw"
       @close="showModalDocuments = false"
     />
   </div>

--- a/client/src/views/Knowledge/DocsCards/DocsCards.vue
+++ b/client/src/views/Knowledge/DocsCards/DocsCards.vue
@@ -156,6 +156,7 @@
     get searchPills (): (KeyValuePill | TextPill)[] {
       return [
         new TextPill(QUERY_FIELDS_MAP.COSMOS_QUERY),
+        new TextPill(QUERY_FIELDS_MAP.COSMOS_ASKE_ID),
         new KeyValuePill(
           QUERY_FIELDS_MAP.COSMOS_TYPE,
           modelTypeUtil.COSMOS_TYPE_OPTIONS,

--- a/client/src/views/Knowledge/DocsCards/DocsCards.vue
+++ b/client/src/views/Knowledge/DocsCards/DocsCards.vue
@@ -156,6 +156,7 @@
     get searchPills (): (KeyValuePill | TextPill)[] {
       return [
         new TextPill(QUERY_FIELDS_MAP.COSMOS_QUERY),
+        new TextPill(QUERY_FIELDS_MAP.COSMOS_DOI),
         new TextPill(QUERY_FIELDS_MAP.COSMOS_ASKE_ID),
         new KeyValuePill(
           QUERY_FIELDS_MAP.COSMOS_TYPE,

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -114,6 +114,7 @@
   import { RawLocation } from 'vue-router';
   import { Watch } from 'vue-property-decorator';
   import { bgraph } from '@uncharted.software/bgraph';
+  import { merge } from 'lodash';
 
   import {
     filterToBgraph,
@@ -360,9 +361,23 @@
           }) as GroMEt.CodeCollectionInterface;
 
           if (codeCollection?.global_reference_id?.id) {
-            this.drilldownKnowledge = await cosmosSearch(filterToParamObj({
+            this.drilldownKnowledge = merge(this.drilldownKnowledge, await cosmosSearch(filterToParamObj({
               askeId: codeCollection.global_reference_id.id,
-            }));
+            })));
+          }
+
+          const textualDocumentReference = this.selectedGraphMetadata.find(metadata => {
+            return metadata.metadata_type === GroMEt.MetadataType.TextualDocumentReferenceSet;
+          }) as GroMEt.TextualDocumentReferenceSet;
+
+          if (textualDocumentReference?.documents?.length) {
+            this.drilldownKnowledge = merge(this.drilldownKnowledge, await cosmosSearch(filterToParamObj({
+              askeId: textualDocumentReference.documents[0].global_reference_id.id,
+            })));
+          }
+
+          if (this.drilldownKnowledge.objects) {
+            delete this.drilldownKnowledge.error;
           }
         }
       } catch (e) {

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -10,6 +10,7 @@
         slot="content"
         v-if="activeTabId === 'metadata'"
         :metadata="selectedGraphMetadata"
+        @open-modal="onOpenModalMetadata"
       />
     </left-side-panel>
 
@@ -125,7 +126,7 @@
   import * as Model from '@/types/typesModel';
   import * as GroMEt from '@/types/typesGroMEt';
   import { CosmosSearchInterface } from '@/types/typesCosmos';
-  import { cosmosArtifactSrc, cosmosSearch, cosmosRelatedParameters } from '@/services/CosmosFetchService';
+  import { cosmosArtifactSrc, cosmosSearch, cosmosRelatedParameters, cosmosArtifactsMem } from '@/services/CosmosFetchService';
   import { filterToParamObj } from '@/utils/CosmosDataUtil';
 
   import { NodeTypes } from '@/graphs/svg/encodings';
@@ -417,8 +418,14 @@
       this.showModalParameters = true;
     }
 
-    onOpenModalMetadata ():void {
-      // this.modalDataMetadata = bibjson;
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    async onOpenModalMetadata (doc: any): Promise<void> {
+      if (doc) {
+        this.modalDataMetadata = merge(
+          await cosmosArtifactsMem({ aske_id: doc.global_reference_id.id }),
+          doc,
+        );
+      }
       this.showModalMetadata = true;
     }
   }

--- a/client/src/views/Models/Model.vue
+++ b/client/src/views/Models/Model.vue
@@ -363,7 +363,7 @@
 
           if (codeCollection?.global_reference_id?.id) {
             this.drilldownKnowledge = merge(this.drilldownKnowledge, await cosmosSearch(filterToParamObj({
-              askeId: codeCollection.global_reference_id.id,
+              cosmosAskeId: codeCollection.global_reference_id.id,
             })));
           }
 
@@ -373,7 +373,7 @@
 
           if (textualDocumentReference?.documents?.length) {
             this.drilldownKnowledge = merge(this.drilldownKnowledge, await cosmosSearch(filterToParamObj({
-              askeId: textualDocumentReference.documents[0].global_reference_id.id,
+              cosmosAskeId: textualDocumentReference.documents[0].global_reference_id.id,
             })));
           }
 

--- a/client/src/views/Models/components/DrilldownPanel/KnowledgePane.vue
+++ b/client/src/views/Models/components/DrilldownPanel/KnowledgePane.vue
@@ -3,7 +3,7 @@
      <div v-if="!isEmptyData" class="mt-3 documents-container hide-scrollbar">
       <div class="mb-1 px-2 py-4 d-flex rounded-lg border" v-for="(object, index) in data.objects" :key="index">
         <div class="flex-grow-1">
-            <a :href="object.bibjson.link[0].url" target="_blank">
+            <a href="/" @click="e => openModal(e, index)">
                 <h6>{{object.bibjson.title}}</h6>
             </a>
             <div> {{object.bibjson.identifier[0].id}}</div>
@@ -15,6 +15,11 @@
         No metadata at the moment.
       </span>
     </message-display>
+    <modal-document
+      v-if="showModal"
+      :data="modalData"
+      @close="showModal = false"
+    />
   </div>
 </template>
 
@@ -25,12 +30,14 @@
   import Vue from 'vue';
   import { Prop } from 'vue-property-decorator';
 
-  import { CosmosSearchInterface } from '@/types/typesCosmos';
+  import { CosmosSearchInterface, CosmosSearchObjectsInterface } from '@/types/typesCosmos';
 
   import MessageDisplay from '@/components/widgets/MessageDisplay.vue';
+  import ModalDocument from '@/components/Modals/ModalDocument.vue';
 
   const components = {
     MessageDisplay,
+    ModalDocument,
   };
 
   @Component({ components })
@@ -38,14 +45,17 @@
     @Prop({ default: null }) data: CosmosSearchInterface;
 
     showModal: boolean = false;
+    modalData: CosmosSearchObjectsInterface = null;
     dataLoading = false;
 
     get isEmptyData (): boolean {
       return _.isEmpty(this.data.objects) || Boolean(this.data.error);
     }
 
-    showMoreHandler (doi: string): void {
-      this.$emit('open-modal', doi);
+    openModal (e: Event, index: number): void {
+      this.showModal = true;
+      this.modalData = this.data.objects[index];
+      e.preventDefault();
     }
   }
 </script>

--- a/client/src/views/Models/components/DrilldownPanel/KnowledgePane.vue
+++ b/client/src/views/Models/components/DrilldownPanel/KnowledgePane.vue
@@ -3,9 +3,9 @@
      <div v-if="!isEmptyData" class="mt-3 documents-container hide-scrollbar">
       <div class="mb-1 px-2 py-4 d-flex rounded-lg border" v-for="(object, index) in data.objects" :key="index">
         <div class="flex-grow-1">
-            <a href="/" @click="e => openModal(e, index)">
+            <div type="button" class="btn-link" @click="openModal(index)">
                 <h6>{{object.bibjson.title}}</h6>
-            </a>
+            </div>
             <div> {{object.bibjson.identifier[0].id}}</div>
         </div>
       </div>
@@ -52,10 +52,9 @@
       return _.isEmpty(this.data.objects) || Boolean(this.data.error);
     }
 
-    openModal (e: Event, index: number): void {
+    openModal (index: number): void {
       this.showModal = true;
       this.modalData = this.data.objects[index];
-      e.preventDefault();
     }
   }
 </script>

--- a/client/src/views/Models/components/DrilldownPanel/KnowledgePane.vue
+++ b/client/src/views/Models/components/DrilldownPanel/KnowledgePane.vue
@@ -41,7 +41,7 @@
     dataLoading = false;
 
     get isEmptyData (): boolean {
-      return _.isEmpty(this.data) || Boolean(this.data.error);
+      return _.isEmpty(this.data.objects) || Boolean(this.data.error);
     }
 
     showMoreHandler (doi: string): void {

--- a/client/src/views/Models/components/MetadataPanel.vue
+++ b/client/src/views/Models/components/MetadataPanel.vue
@@ -36,16 +36,11 @@
       <template v-else-if="isTypeDocuments(datum)">
         <summary :title="datum.uid">Documents</summary>
         <div class="metadata-content">
-          <details v-for="(doc, index) in datum.documents" :key="index">
-            <summary :title="doc.uid">
-              <a :href="doc.bibjson.website.url">{{ doc.bibjson.title }}</a>
-              {{ doc.global_reference_id.type }} {{ doc.global_reference_id.id }}
-            </summary>
-            <h6>File</h6>
-            <p><a :href="doc.bibjson.file_url">{{ doc.bibjson.file }}</a></p>
-            <h6>Author(s)</h6>
-            <p>{{ doc.bibjson.author.map(a => a.name) | ArrayToList }}</p>
-          </details>
+          <summary v-for="(doc, index) in datum.documents" :key="index" :title="doc.uid">
+            <a :href="doc.bibjson.website.url">{{ doc.bibjson.title }}</a>
+            {{ doc.global_reference_id.type }} {{ doc.global_reference_id.id }}
+            <div class="mt-3"><a href="/" @click="e => openModal(e, doc)">Show more...</a></div>
+          </summary>
         </div>
       </template>
 
@@ -85,6 +80,11 @@
 
     provenanceDate (timestamp: string): string {
       return formatFullDateTime(timestamp);
+    }
+
+    openModal (e: Event, datum: GroMET.Metadata): void {
+      this.$emit('open-modal', datum);
+      e.preventDefault();
     }
   }
 </script>

--- a/client/src/views/Models/components/MetadataPanel.vue
+++ b/client/src/views/Models/components/MetadataPanel.vue
@@ -39,7 +39,7 @@
           <summary v-for="(doc, index) in datum.documents" :key="index" :title="doc.uid">
             <a :href="doc.bibjson.website.url">{{ doc.bibjson.title }}</a>
             {{ doc.global_reference_id.type }} {{ doc.global_reference_id.id }}
-            <div class="mt-3"><a href="/" @click="e => openModal(e, doc)">Show more...</a></div>
+            <div type="button" class="mt-3 btn-link" @click="openModal(doc)">Show more...</div>
           </summary>
         </div>
       </template>
@@ -82,9 +82,8 @@
       return formatFullDateTime(timestamp);
     }
 
-    openModal (e: Event, datum: GroMET.Metadata): void {
+    openModal (datum: GroMET.Metadata): void {
       this.$emit('open-modal', datum);
-      e.preventDefault();
     }
   }
 </script>

--- a/client/src/views/Models/components/Modals/ModalDocMetadata.vue
+++ b/client/src/views/Models/components/Modals/ModalDocMetadata.vue
@@ -4,7 +4,7 @@
       <a :href="data.bibjson.link[0].url" target="_blank">
         <h3>{{ data.bibjson.title }}</h3>
       </a>
-      <h5>{{ data.bibjson.identifier[0].id }}</h5>
+      <h5>{{ doi }}</h5>
     </div>
     <div slot="body" >
       <div class="d-flex flex-grow-1">
@@ -14,7 +14,15 @@
             <div class="font-weight-bolder mt-3">Publication Year</div>
             <div>{{ data.bibjson.year || 'None' }}</div>
             <div class="font-weight-bolder mt-3">Publisher</div>
-            <div>{{ data.publisher || 'None' }}</div>
+            <div>{{ data.publisher || data.bibjson.publisher || 'None' }}</div>
+            <template v-if="data.bibjson.file_url">
+              <div class="font-weight-bolder mt-3">File</div>
+              <div>
+                <a target="_blank" :href="data.bibjson.file_url">
+                  {{ data.bibjson.file }}
+                </a>
+              </div>
+            </template>
           </div>
       </div>
     </div>
@@ -50,14 +58,17 @@
       return getAuthorList(this.data?.bibjson);
     }
 
+    get doi (): string {
+      return this.data?.bibjson?.identifier[0]?.id;
+    }
+
     close (): void {
       this.$emit('close', null);
     }
 
     openKnowledgeView () : void {
       const name = 'docsCards';
-      const doi = this.data?.bibjson?.identifier[0]?.id;
-      const args = doi ? { name, query: { doi } } : { name };
+      const args = this.doi ? { name, query: { doi: this.doi } } : { name };
       this.$router.push(args);
     }
   }


### PR DESCRIPTION
The following changes were made in this PR (sorry the branch name is misleading)

- In the right side knowledge panel of the models view, allow aske-ids from both code collection and text reference metadata types to be used in generating the knowledge list. If both metadata types exist, then the results will be combined
- In the right side knowledge panel of the models view, if a knowledge title is clicked, then instead of opening an external link to the knowledge source, open a modal identical to those used in the docCards view showing the knowledge result metadata
- In the left side metadata panel of the models view, modify the documents section so that instead of a dropdown providing more metadata, a modal containing the metadata is opened instead
- In the dosCards view, searching by aske-id is now permitted (Fixes #343)

To test: verify all this is correct

Notes:
- I notice that the stacking order is incorrect when the right side knowledge panel model is opened, the reason for this is explained in the following and can be resolved by removing the z-index from `.drilldown-panel-container`. Anyone got any reason why this is not safe to do?
- You will need to modify the code to test the right side knowledge panel because we arent getting metadata results from the current gromet. To do this, comment out line 376 in Model.vue.