### PR TITLE
Fix parameters panel error issue

### DIFF
--- a/client/src/store/modules/simulation.ts
+++ b/client/src/store/modules/simulation.ts
@@ -109,11 +109,20 @@ const actions: ActionTree<HMI.SimulationState, HMI.SimulationParameter[]> = {
 
   async initializeParameters ({ commit }, args: { model: Model.Model, selectedModelGraphType: Model.GraphTypes }): Promise<void> {
     const donuParameters = await getModelParameters(args.model, args.selectedModelGraphType) ?? [];
-    const parameters = donuParameters.map(donuParameter => ({
-      ...donuParameter,
-      displayed: false,
-      values: [donuParameter.default],
-    }));
+    const parameters = donuParameters.map(donuParameter => {
+      const parameter = {
+        ...donuParameter,
+        displayed: false,
+        values: [donuParameter.default],
+      };
+
+      // If the API does not provide a name, we leverage the UID.
+      if (!parameter.metadata.name) {
+        parameter.metadata.name = parameter.uid;
+      }
+
+      return parameter;
+    });
     commit('setSimParameters', { modelId: args.model.id, parameters });
     commit('setNumberOfSavedRuns', 0);
   },

--- a/client/src/store/modules/simulation.ts
+++ b/client/src/store/modules/simulation.ts
@@ -3,6 +3,7 @@ import * as HMI from '@/types/types';
 import * as Model from '@/types/typesModel';
 import { getModelParameters, getModelResult, getModelVariables } from '@/services/DonuService';
 import * as d3 from 'd3';
+import _ from 'lodash';
 
 const state: HMI.SimulationState = {
   numberOfSavedRuns: 0,
@@ -109,7 +110,11 @@ const actions: ActionTree<HMI.SimulationState, HMI.SimulationParameter[]> = {
 
   async initializeParameters ({ commit }, args: { model: Model.Model, selectedModelGraphType: Model.GraphTypes }): Promise<void> {
     const donuParameters = await getModelParameters(args.model, args.selectedModelGraphType) ?? [];
-    const parameters = donuParameters.map(donuParameter => {
+
+    // Filter out parameters with the same not so unique UID.
+    const uniqueDonuParameters = _.uniqBy(donuParameters, 'uid');
+
+    const parameters = uniqueDonuParameters.map(donuParameter => {
       const parameter = {
         ...donuParameter,
         displayed: false,
@@ -123,6 +128,7 @@ const actions: ActionTree<HMI.SimulationState, HMI.SimulationParameter[]> = {
 
       return parameter;
     });
+
     commit('setSimParameters', { modelId: args.model.id, parameters });
     commit('setNumberOfSavedRuns', 0);
   },

--- a/client/src/views/Simulation/components/ParametersPanel.vue
+++ b/client/src/views/Simulation/components/ParametersPanel.vue
@@ -365,7 +365,6 @@
     grid-template-rows: 1fr 1fr;
     height: var(--parameter-height);
     padding: var(--padding);
-    scroll-snap-align: start;
   }
 
   .parameter:last-of-type {


### PR DESCRIPTION
They were a simple issue from the DONU API that will send multiple parameters with same UID. Unfortunately they are not so _unique_. So we filter them out.

Also they will sometimes not provide a `metadata.name` for the parameters, so we use the UID in those occasions.