### PR TITLE
Refactored model comparison system and added support for multi-model comparison linked node highlighting

### DIFF
--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -231,7 +231,7 @@ export default class EpiRenderer extends SVGRenderer {
     const nodes = subgraph.nodes;
     if (chart) {
       chart.selectAll('.node-ui').each(function (d) {
-        if (nodes.map(node => node.id).includes(d.label)) {
+        if (nodes.some(node => node.id === d.label)) {
           d3.select(this)
             .select('rect, ellipse')
             .style('stroke', Colors.HIGHLIGHT)

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -206,7 +206,9 @@ export default class EpiRenderer extends SVGRenderer {
 
   hideSubgraph (): void {
     const chart = (this as any).chart;
-    chart.selectAll('.node-ui,.edge').style('opacity', 1);
+    if (chart) {
+      chart.selectAll('.node-ui,.edge').style('opacity', 1);
+    }
   }
 
   showSubgraph (subgraph: SubgraphInterface): void {
@@ -222,6 +224,25 @@ export default class EpiRenderer extends SVGRenderer {
       const isNeighbour = nodes.map(node => node).includes(d.id);
       d3.select(this).style('opacity', isNeighbour ? '1' : '0.1');
     });
+  }
+
+  showHighlight (subgraph: SubgraphInterface): void {
+    const chart = (this as any).chart;
+    const nodes = subgraph.nodes;
+    if (chart) {
+      chart.selectAll('.node-ui').each(function (d) {
+        if (nodes.map(node => node.id).includes(d.label)) {
+          d3.select(this)
+            .select('rect, ellipse')
+            .style('stroke', Colors.HIGHLIGHT)
+            .style('stroke-width', DEFAULT_STYLE.node.strokeWidth + 3);
+        } else {
+          d3.select(this)
+            .select('rect, ellipse')
+            .style('stroke-width', DEFAULT_STYLE.node.strokeWidth);
+        }
+      });
+    }
   }
 
   selectNode (node: d3.Selection<any, any, any, any>): void {

--- a/client/src/store/modules/model.ts
+++ b/client/src/store/modules/model.ts
@@ -4,6 +4,7 @@ import { processModelComparison } from '@/utils/ModelUtil';
 import * as Model from '@/types/typesModel';
 import * as Graphs from '@/types/typesGraphs';
 
+// Temporary model comparison data until data available on donu
 // Model names modified
 const MODEL_COMPARISON = {
   apex: 'SimpleSIR_metadata',
@@ -53,7 +54,7 @@ const getters: GetterTree<Model.State, any> = {
   getCountComputationalModels: (state): number => state.modelsList.length,
   getModelComparisonMap: (): Model.ModelComparisonMap => processModelComparison(MODEL_COMPARISON),
   getSharedNodes: (state, getters) => (modelId: number): Graphs.SubgraphInterface => {
-    const selectedModel = state.modelsList.find(model => model.id === modelId).name;
+    const selectedModel = state.modelsList.find(model => model.id === modelId)?.name;
     const comparedModels = state.modelsList
       .filter(model => model.id !== modelId && state.selectedModelIds.has(model.id))
       .map(model => model.name);

--- a/client/src/store/modules/model.ts
+++ b/client/src/store/modules/model.ts
@@ -1,12 +1,38 @@
 import { GetterTree, MutationTree, ActionTree } from 'vuex';
 import { fetchDonuModels } from '@/services/DonuService';
+import { processModelComparison } from '@/utils/ModelUtil';
 import * as Model from '@/types/typesModel';
+import * as Graphs from '@/types/typesGraphs';
+
+// Model names modified
+const MODEL_COMPARISON = {
+  apex: 'SimpleSIR_metadata',
+  legs: {
+    'SimpleChime+': [
+      {
+        'J:gamma': 'J:rec_u',
+        'J:I': 'J:I_U',
+        'J:R': 'J:R',
+        'J:S': 'J:S',
+        'J:beta': 'J:inf_uu',
+      },
+      {
+        'J:gamma': 'J:rec_v',
+        'J:I': 'J:I_V',
+        'J:R': 'J:R',
+        'J:S': 'J:V',
+        'J:beta': 'J:inf_vv',
+      },
+    ],
+  },
+};
 
 const state: Model.State = {
   isInitialized: false,
   selectedModelIds: new Set(),
   modelsList: [],
   selectedModelGraphType: Model.GraphTypes.PetriNetClassic, // Petri Net Classic as default
+  selectedNodes: [],
 };
 
 const actions: ActionTree<Model.State, any> = {
@@ -25,6 +51,42 @@ const getters: GetterTree<Model.State, any> = {
   getSelectedModelIds: state => [...state.selectedModelIds],
   getSelectedModelGraphType: state => state.selectedModelGraphType,
   getCountComputationalModels: (state): number => state.modelsList.length,
+  getModelComparisonMap: (): Model.ModelComparisonMap => processModelComparison(MODEL_COMPARISON),
+  getSharedNodes: (state, getters) => (modelId: number): Graphs.SubgraphInterface => {
+    const selectedModel = state.modelsList.find(model => model.id === modelId).name;
+    const comparedModels = state.modelsList
+      .filter(model => model.id !== modelId && state.selectedModelIds.has(model.id))
+      .map(model => model.name);
+    const comparisonMap = getters.getModelComparisonMap[selectedModel];
+    const nodes: Set<string> = new Set();
+
+    for (const compareTo in comparisonMap) {
+      if (comparedModels.includes(compareTo)) {
+        Object.keys(comparisonMap[compareTo]).forEach(nodeName => nodes.add(nodeName));
+      }
+    }
+    return { nodes: [...nodes].map(node => ({ id: node })), edges: [] };
+  },
+  getSelectedNodes: (state, getters) => (modelId: number): Graphs.SubgraphInterface => {
+    const selectedModel = state.modelsList.find(model => model.id === modelId).name;
+    const nodes: Set<string> = new Set();
+
+    state.selectedNodes.forEach(selectedNode => {
+      const selectedNodeModel = state.modelsList.find(model => model.id === selectedNode.model).name;
+      if (selectedNodeModel === selectedModel) {
+        nodes.add(selectedNode.node);
+      } else {
+        const comparisonMap = getters.getModelComparisonMap[selectedNodeModel][selectedModel];
+        const selectedNodeIdArray = comparisonMap?.[selectedNode.node]?.values();
+        if (selectedNodeIdArray) {
+          for (const selectedNodeId of selectedNodeIdArray) {
+            nodes.add(selectedNodeId);
+          }
+        }
+      }
+    });
+    return { nodes: [...nodes].map(node => ({ id: node })), edges: [] };
+  },
 };
 
 const mutations: MutationTree<Model.State> = {
@@ -58,6 +120,10 @@ const mutations: MutationTree<Model.State> = {
 
   resetSelectedModelIds (state: Model.State) {
     state.selectedModelIds = new Set();
+  },
+
+  setSelectedNodes (state, selectedNodes: Model.SelectedNode[]) {
+    state.selectedNodes = selectedNodes;
   },
 };
 

--- a/client/src/types/typesModel.ts
+++ b/client/src/types/typesModel.ts
@@ -51,9 +51,9 @@ type ModelComparisonData = {
 };
 
 type ModelComparisonMap = {
-  [key: string]: {
-    [key: string]: {
-      [key: string]: Set<string>,
+  [key: string]: { // Compare Against Model ID (name)
+    [key: string]: { // Compare To Model ID (name)
+      [key: string]: Set<string>, // Compare Against Node ID (name): Set<Compare To Node ID (name)>
     }
   }
 };

--- a/client/src/types/typesModel.ts
+++ b/client/src/types/typesModel.ts
@@ -41,11 +41,34 @@ type Model = {
   metadata?: Metadata,
 };
 
+type ModelComparisonData = {
+  apex: string,
+  legs: {
+    [key: string]: {
+      [key: string]: string,
+    }[]
+  }
+};
+
+type ModelComparisonMap = {
+  [key: string]: {
+    [key: string]: {
+      [key: string]: Set<string>,
+    }
+  }
+};
+
+type SelectedNode = {
+  model: number,
+  node: string,
+};
+
 type State = {
   isInitialized: boolean,
   modelsList: Model[],
   selectedModelGraphType?: GraphTypes,
-  selectedModelIds: Set<string>,
+  selectedModelIds: Set<number>,
+  selectedNodes: SelectedNode[],
 };
 
 export {
@@ -54,5 +77,8 @@ export {
   GraphTypes,
   Model,
   Metadata,
+  ModelComparisonData,
+  ModelComparisonMap,
+  SelectedNode,
   State,
 };

--- a/client/src/utils/ModelUtil.ts
+++ b/client/src/utils/ModelUtil.ts
@@ -1,0 +1,57 @@
+import * as Model from '@/types/typesModel';
+
+/**
+ * Find all model comparisons which do not have an inverse map in the data (e.g. model1 -> model2
+ * exists but model2 -> model1 does not) and generates the inverse map using the pre-existing forward map.
+ * @returns {Model.ModelComparisonMap} Returns a model comparison map augmented with the generated
+ * inverse data.
+ */
+const generateComparisonPairs = (input: Model.ModelComparisonMap): Model.ModelComparisonMap => {
+  for (const compareAgainst in input) {
+    for (const compareTo in input[compareAgainst]) {
+      if (!input[compareTo]?.[compareAgainst]) {
+        const keys = Object.keys(input[compareAgainst][compareTo]);
+        const values = Object.values(input[compareAgainst][compareTo]);
+
+        if (!input[compareTo]) {
+          input[compareTo] = {};
+        }
+        input[compareTo][compareAgainst] = {};
+        for (let i = 0; i < keys.length; i++) {
+          for (const value of values[i]) {
+            if (!input[compareTo][compareAgainst][value]) {
+              input[compareTo][compareAgainst][value] = new Set();
+              input[compareTo][compareAgainst][value].add(keys[i]);
+            }
+          }
+        }
+      }
+    }
+  }
+  return input;
+};
+
+/**
+ * Parse Model Comparison data structure into a more convenient form. Remove "J:" prefix attached
+ * to node names in the raw comparison data.
+ * @returns {Model.ModelComparisonMap} Returns a model comparison map generated from the input
+ * model comparison data, where every comparison has both forward and inverse comparisons provided.
+ */
+export const processModelComparison = (input: Model.ModelComparisonData): Model.ModelComparisonMap => {
+  const comparisonMap = { [input.apex]: {} };
+  const compareAgainst = comparisonMap[input.apex];
+  for (const compareTo in input.legs) {
+    compareAgainst[compareTo] = compareAgainst[compareTo] ?? {};
+    input.legs[compareTo].forEach(compareSet => {
+      for (let compareAgainstKey in compareSet) {
+        compareAgainstKey = compareAgainstKey.substr(2);
+        if (!compareAgainst[compareTo][compareAgainstKey]) {
+          compareAgainst[compareTo][compareAgainstKey] = new Set();
+        }
+        compareAgainst[compareTo][compareAgainstKey].add(compareSet['J:' + compareAgainstKey].substr(2));
+      }
+    });
+  }
+
+  return generateComparisonPairs(comparisonMap);
+};

--- a/client/src/views/Comparison/Comparison.vue
+++ b/client/src/views/Comparison/Comparison.vue
@@ -82,7 +82,7 @@
         this.$route.params.model_id.split(',').forEach(this.setSelectedModels);
       }
 
-      return this.getModelsList.filter(model => this.getSelectedModelIds.map(Number).includes(model.id));
+      return this.getModelsList.filter(model => this.getSelectedModelIds.includes(model.id));
     }
 
     get gridMap (): string[][] {

--- a/client/src/views/Comparison/Comparison.vue
+++ b/client/src/views/Comparison/Comparison.vue
@@ -29,7 +29,6 @@
           class="comparison-panel"
           :key="index"
           :model="model"
-          :overlapping-elements="model.modelGraph[0].overlappingElements"
           :slot="('model_' + model.id)"
           :expandable="false"
         />
@@ -45,7 +44,6 @@
   import { RawLocation } from 'vue-router';
 
   import * as Model from '@/types/typesModel';
-  // import * as Graph from '@/types/typesGraphs';
   import * as RGrid from '@/types/typesResizableGrid';
 
   import Counters from '@/components/Counters.vue';
@@ -54,14 +52,6 @@
   import SearchBar from '@/components/SearchBar.vue';
 
   import ModelPanel from '@/views/Simulation/components/ModelPanel.vue';
-
-  const MODEL_COMPARISON = {
-    gamma: 'rec_u',
-    I: 'I_U',
-    R: 'R',
-    S: 'S',
-    beta: 'inf_uu',
-  };
 
   const components = {
     Counters,
@@ -92,18 +82,7 @@
         this.$route.params.model_id.split(',').forEach(this.setSelectedModels);
       }
 
-      const selectedModels = this.getModelsList.filter(model => this.getSelectedModelIds.map(Number).includes(model.id));
-      // HACK: Adding the overlapping elements to the model graph information
-      let nodes = [];
-      selectedModels.forEach(model => {
-        if (model.name === 'SimpleSIR_metadata') {
-          nodes = Object.keys(MODEL_COMPARISON).map(node => ({ id: node }));
-        } else if (model.name === 'SimpleChime+') {
-          nodes = Object.values(MODEL_COMPARISON).map(node => ({ id: node }));
-        }
-        model.modelGraph[0].overlappingElements = { nodes, edges: [] };
-      });
-      return selectedModels;
+      return this.getModelsList.filter(model => this.getSelectedModelIds.map(Number).includes(model.id));
     }
 
     get gridMap (): string[][] {

--- a/client/src/views/Models/components/Graphs/GlobalGraph.vue
+++ b/client/src/views/Models/components/Graphs/GlobalGraph.vue
@@ -29,6 +29,7 @@
   export default class GlobalGraph extends Vue {
     @Prop({ default: null }) data: GraphInterface;
     @Prop({ default: null }) subgraph: SubgraphInterface;
+    @Prop({ default: null }) highlight: SubgraphInterface;
     @Prop({ default: () => [] }) displayedNodes: SubgraphNodeInterface[];
     @Prop({ default: null }) overlappingElements: SubgraphInterface;
     @Prop({ default: GraphLayoutInterfaceType.elk }) layout: string;
@@ -43,30 +44,44 @@
 
     @Watch('subgraph')
     onSubgraphChange (): void {
-      this.subgraphChanged();
+      this.dataDecorationChanged();
+    }
+
+    @Watch('highlight')
+    onHighlightChange (): void {
+      this.dataDecorationChanged();
     }
 
     @Watch('layout')
     async layoutChanged (): Promise<void> {
       await this.refresh();
-      this.subgraphChanged();
+      this.dataDecorationChanged();
     }
 
     @Watch('displayedNodes')
-    async displayedNodesChanged (): Promise<void> {
-      this.renderer.markDisplayedNodes(this.displayedNodes);
+    displayedNodesChanged (): void {
+      this.dataDecorationChanged();
     }
 
     @Watch('overlappingElements')
     overlappingElementsChanged ():void {
-      this.renderer.markOverlappingElements(this.overlappingElements);
+      this.dataDecorationChanged();
     }
 
-    subgraphChanged (): void {
+    dataDecorationChanged (): void {
       if (this.subgraph) {
         this.renderer.showSubgraph(this.subgraph);
       } else {
         this.renderer.hideSubgraph();
+      }
+      if (this.displayedNodes) {
+        this.renderer.markDisplayedNodes(this.displayedNodes);
+      }
+      if (this.overlappingElements) {
+        this.renderer.markOverlappingElements(this.overlappingElements);
+      }
+      if (this.highlight) {
+        this.renderer.showHighlight(this.highlight);
       }
     }
 

--- a/client/src/views/Simulation/components/ModelPanel.vue
+++ b/client/src/views/Simulation/components/ModelPanel.vue
@@ -36,7 +36,8 @@
       v-if="graph"
       :data="graph"
       :displayed-nodes="displayedNodes"
-      :overlapping-elements="overlappingElements"
+      :overlapping-elements="getSharedNodes(model.id)"
+      :highlight="getSelectedNodes(model.id)"
       @node-click="onNodeClick"
       @background-click="onBackgroundClick"
       @node-dblclick="onNodeDblClick"
@@ -48,7 +49,7 @@
   import Vue from 'vue';
   import Component from 'vue-class-component';
   import { Prop } from 'vue-property-decorator';
-  import { Action, Getter } from 'vuex-class';
+  import { Action, Getter, Mutation } from 'vuex-class';
   import * as HMI from '@/types/types';
   import * as Model from '@/types/typesModel';
   import * as Graph from '@/types/typesGraphs';
@@ -67,10 +68,12 @@
     @Prop({ default: false }) expanded: boolean;
     @Prop({ default: null }) model: Model.Model;
     @Prop({ default: true }) expandable: boolean;
-    @Prop({ default: null }) overlappingElements: Graph.SubgraphInterface;
 
     @Getter getSimModel;
     @Getter getSelectedModelGraphType;
+    @Getter getSharedNodes;
+    @Getter getSelectedNodes;
+    @Mutation setSelectedNodes;
 
     @Action hideAllParameters;
     @Action showAllParameters;
@@ -83,11 +86,11 @@
     settingsOpen: boolean = false;
 
     onNodeClick (selected: Graph.GraphNodeInterface): void {
-      this.$emit('highlight', { label: selected.label, modelName: this.modelName });
+      this.setSelectedNodes([{ model: this.model.id, node: selected.label }]);
     }
 
     onBackgroundClick (): void {
-      this.$emit('highlight', null);
+      this.setSelectedNodes([]);
     }
 
     onNodeDblClick (selected: Graph.GraphNodeInterface): void {


### PR DESCRIPTION
This PR accomplishes the following:

- Moves node selection from view files into the model store and created functions to calculate shared nodes and selected nodes given a specific model
- Adds highlight property to `EpiRenderer`
- Allows for (mostly) direct consumption of data provided by GTRI, Galois, etc. (Had to change the model names to match the model names fetched from donu)
- Supports one-to-many model comparison (demonstrated in the video)
- Full support for 2 model comparison with partial support for n model comparison (demonstrated in the video with rigged comparison input data) (full support requires model comparison data for each model to be compared and a function to combine multiple comparison data sources)

To test:
Click around the comparison view with the `SimpleSIR_metadata` and `SimpleChime+` functions

Notes:
- Right now the models view uses a different selection system (default node click highlight) compared to the comparison view (models store). This is not visible in the HMI but we might want to consider switching over the models view to use the new system later for consistency.
- Slightly concerned for efficiency, particularly with the `dataDecorationChanged` function

https://user-images.githubusercontent.com/14062458/129421371-785585d6-6c71-4abc-b5b9-bdd7edc3933f.mov


