### PR TITLE
[FEATURE] Add document cluster queries

### DIFF
--- a/client/src/utils/BGraphQueryUtil.ts
+++ b/client/src/utils/BGraphQueryUtil.ts
@@ -150,6 +150,20 @@ const bioNodeOutDegree = (bgraphPathQuery, clause: Filter): any => {
   });
 };
 
+const docsNodeTitle = (bgraphPathQuery, clause: Filter): any => {
+  let titles = clause.values as string[];
+  // Filter fuzzy matches case insensitive titles
+  titles = titles.map(title => title.toLowerCase());
+  return bgraphPathQuery.filter(document => {
+    if (document._type === 'node') {
+      const node = document;
+      return titles.some(title => node.label.toLowerCase().includes(title));
+    }
+    // Document is not a node
+    return false;
+  });
+};
+
 // EPI PATH QUERIES
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const epiPathPre = (bgraphPathQuery, clause: Filter): any => {
@@ -220,6 +234,8 @@ export const filterTermToPriorityRank = {
   [QUERY_FIELDS_MAP.EPI_PATH_PRE_NODE_FILTER_LOOP.field]: 3,
   [QUERY_FIELDS_MAP.EPI_PATH.field]: PATH_PRIORITY_RANK,
   [QUERY_FIELDS_MAP.EPI_PATH_POST.field]: 8,
+  // DOCS Node Terms
+  [QUERY_FIELDS_MAP.DOCS_NODE_TITLE.field]: NODE_PRIORITY_RANK,
 };
 
 // Assume that bgraph instance passed in has already been initialized
@@ -275,6 +291,12 @@ export const executeBgraphNodes = (bgraphNodeQuery: any, clause: Filter): any =>
     case QUERY_FIELDS_MAP.BIO_NODE_IN_DEGREE.field: return bioNodeInDegree(bgraphNodeQuery, clause);
     case QUERY_FIELDS_MAP.BIO_NODE_OUT_DEGREE.field: return bioNodeOutDegree(bgraphNodeQuery, clause);
     case QUERY_FIELDS_MAP.BIO_NODE_POST.field: return bgraphNodeQuery;
+    // DOC CLAUSES
+    // TODO: Currently we are using the BIO_NODE_PRE/POST for document cluster queries
+    // as they both just return the query but may want to differentiate in the future.
+    // case QUERY_FIELDS_MAP.DOCS_NODE_PRE.field: return bgraphNodeQuery;
+    case QUERY_FIELDS_MAP.DOCS_NODE_TITLE.field: return docsNodeTitle(bgraphNodeQuery, clause);
+    // case QUERY_FIELDS_MAP.DOCS_NODE_POST.field: return bgraphNodeQuery;
     default: return bgraphNodeQuery;
   }
 };

--- a/client/src/utils/GraferUtil.ts
+++ b/client/src/utils/GraferUtil.ts
@@ -135,6 +135,28 @@ export const CLUSTER_GRAPH_COLORS = [
   COLORS.AURORA_4_GREEN, // Used for nodes to signify cluster relationship with other nodes
   COLORS.AURORA_5_PURPLE, // Used for nodes to signify cluster relationship with other nodes
 ];
+export const CLUSTER_NODES_LAYERS_CONFIG = {
+  options: {
+    // Foreground options are meant for layers that a user should focus on
+    foreground: {
+      nodes: {
+        desaturate: 0,
+      },
+      edges: {
+        desaturate: 0,
+      },
+    },
+    // Background options are meant for layers that act as context
+    background: {
+      nodes: {
+        desaturate: 0.9,
+      },
+      edges: {
+        desaturate: 0.9,
+      },
+    },
+  },
+};
 
 export const buildHighlightClusterLayer = (name: string, edges: unknown[], clusters: unknown[]): GraferLayerData => {
   return {

--- a/client/src/utils/QueryFieldsUtil.ts
+++ b/client/src/utils/QueryFieldsUtil.ts
@@ -95,9 +95,16 @@ const QUERY_FIELDS_MAP: QueryFieldMap = {
     baseType: 'integer',
     lexType: 'integer',
   },
-  DOCS_NODE_TITLE: {
-    ..._field('docsTitle', 'Document Title'),
-    ..._searchable('Document Title', false),
+  DOCS_CLUSTERS_NODE_TITLE: {
+    ..._field('docsClustersNodeTitle', 'Keyword'),
+    ..._searchable('Keyword', false),
+    baseType: 'string',
+    lexType: 'string',
+    order: 2,
+  },
+  DOCS_CLUSTERS_NODE_DOI: {
+    ..._field('docsClustersNodeDOI', 'DOI'),
+    ..._searchable('DOI', false),
     baseType: 'string',
     lexType: 'string',
   },

--- a/client/src/utils/QueryFieldsUtil.ts
+++ b/client/src/utils/QueryFieldsUtil.ts
@@ -95,6 +95,12 @@ const QUERY_FIELDS_MAP: QueryFieldMap = {
     baseType: 'integer',
     lexType: 'integer',
   },
+  DOCS_NODE_TITLE: {
+    ..._field('docsTitle', 'Document Title'),
+    ..._searchable('Document Title', false),
+    baseType: 'string',
+    lexType: 'string',
+  },
   BIO_EDGE_PRE: {
     ..._field('bioEdgePre', 'Edge Pre'),
     ..._searchable('Edge Pre', false),

--- a/client/src/views/Knowledge/DocsClusters/DocsClusters.vue
+++ b/client/src/views/Knowledge/DocsClusters/DocsClusters.vue
@@ -229,7 +229,8 @@
 
     get searchPills (): (KeyValuePill | TextPill)[] {
       return [
-        new TextPill(QUERY_FIELDS_MAP.DOCS_NODE_TITLE),
+        new TextPill(QUERY_FIELDS_MAP.DOCS_CLUSTERS_NODE_TITLE),
+        new TextPill(QUERY_FIELDS_MAP.DOCS_CLUSTERS_NODE_DOI),
       ];
     }
 

--- a/client/src/views/Knowledge/components/Graphs/Grafer.vue
+++ b/client/src/views/Knowledge/components/Graphs/Grafer.vue
@@ -6,7 +6,6 @@
 </template>
 
 <script lang="ts">
-  import _ from 'lodash';
   import {
     GraferController,
     GraferNodesType,

--- a/client/src/views/Knowledge/components/Graphs/Grafer.vue
+++ b/client/src/views/Knowledge/components/Graphs/Grafer.vue
@@ -6,6 +6,7 @@
 </template>
 
 <script lang="ts">
+  import _ from 'lodash';
   import {
     GraferController,
     GraferNodesType,
@@ -22,6 +23,9 @@
     GroupHullEdge,
     LayoutInfo,
   } from './convertDataToGraferV4';
+  import {
+    CLUSTER_NODES_LAYERS_CONFIG,
+  } from '@/utils/GraferUtil';
 
   import Loader from '@/components/widgets/Loader.vue';
   import eventHub from '@/eventHub';
@@ -50,7 +54,82 @@
     graferNodesData: any = undefined;
 
     mounted (): void {
-        eventHub.$on('load-grafer-data', this.loadGraph);
+      eventHub.$on('load-grafer-data', this.loadGraph);
+      eventHub.$on('update-layers', (layers: GraferLayerData[], layerNames: string[]) => {
+        this.updateLayers(layers, layerNames);
+      });
+      eventHub.$on('remove-layers', (layerNames: string[]) => {
+          this.removeLayers(layerNames);
+      });
+      eventHub.$on('foreground-full-graph', () => {
+        this.foregroundFullGraph();
+      });
+      eventHub.$on('background-full-graph', () => {
+        this.backgroundFullGraph();
+      });
+    }
+
+    destroyed (): void {
+      eventHub.$off('load-layers');
+      eventHub.$off('update-layers');
+      eventHub.$off('remove-layers');
+      eventHub.$off('foreground-full-graph');
+      eventHub.$off('background-full-graph');
+    }
+
+    removeLayers (layerNames: string[]): void {
+      for (const layerName of layerNames) {
+        this.controller.removeLayerByName(layerName);
+      }
+      this.controller.render();
+    }
+
+    updateLayers (layers: GraferLayerData[], layerNames: string[]): void {
+      for (const layerName of layerNames) {
+        this.controller.removeLayerByName(layerName);
+      }
+      for (let i = 0; i < layers.length; i++) {
+        this.controller.addLayer(layers[i], layerNames[i]);
+      }
+      this.controller.render();
+    }
+
+    foregroundFullGraph (): void {
+      // Get internal pointer to graph layers
+      // NOTE: This is a temporary interface, Grafer is developing a user interface into layers that
+      //       this should be replaced with
+      const layers = this.controller.viewport.graph.layers;
+      layers.forEach(l => {
+        if (l.name.includes('highlight')) {
+          // Ignore query/highlight layers
+          return;
+        }
+        if (l.nodes) {
+          Object.assign(l.nodes, CLUSTER_NODES_LAYERS_CONFIG.options.foreground.nodes);
+        }
+        if (l.edges) {
+          Object.assign(l.edges, CLUSTER_NODES_LAYERS_CONFIG.options.foreground.edges);
+        }
+      });
+    }
+
+    backgroundFullGraph (): void {
+      // Get internal pointer to graph layers
+      // NOTE: This is a temporary interface, Grafer is developing a user interface into layers that
+      //       this should be replaced with
+      const layers = this.controller.viewport.graph.layers;
+      layers.forEach(l => {
+        if (l.name.includes('highlight')) {
+          // Ignore query/highlight layers
+          return;
+        }
+        if (l.nodes) {
+          Object.assign(l.nodes, CLUSTER_NODES_LAYERS_CONFIG.options.background.nodes);
+        }
+        if (l.edges) {
+          Object.assign(l.edges, CLUSTER_NODES_LAYERS_CONFIG.options.background.edges);
+        }
+      });
     }
 
     forwardEvents (controller: GraferController): void {
@@ -286,6 +365,8 @@
 
         this.forwardEvents(this.controller);
         this.loading = false;
+        this.$emit('loaded-layers', layers);
+        this.$emit('loaded');
     }
   }
 


### PR DESCRIPTION
### Description
Add document title and DOI querying to document cluster view.

### Changes
- Add document title query field and query function
- Add document DOI query field and query function
- Add search pills to document cluster view.
- Add document title search pill to document cluster view.
- Add foreground/background doc cluster grafer settings to enable query highlighting.
- Send events between knowledge grafer controller and document cluster view to enable query highlighting. Events added are (1) foreground original data (2) background original data (3) update/add layers (4) remove layers (5) grafer loaded (6) loaded grafer layers

### Considerations
- The document cluster grafer layer/layer data is sent back to the document view to be stored in memory. This is because when a query is made that view will then filter down the data list to just what the query satisfies. The more efficient way of doing this is, instead of filtering existing layers, build up new query layer/layer data from scratch. However, this proved to be  more difficult than worthwhile for this pre-demo sprint.
- We are using fade in the grafer cluster view to differentiate cluster levels/heirarchy; here we are using desaturation to foreground/background the original grafer layers to differentiate original layers from query layers. Occasionally, especially when viewing sparsely populated sections of the ground it can be hard to differentiate between a desaturated node and a node that has been heavily faded. I've decided to keep it for this iteration to get a first pass in.
- The polygons around document nodes are not being highlighted on a query. Enabling this seems important, however, I've left it out of this initial pass as I had run low on time. 

### Testing
- No special instructions.

### Artifacts:
![Screen Shot 2021-08-16 at 10 37 02 AM](https://user-images.githubusercontent.com/15199528/129582086-000e0e10-d065-4e72-89a0-3a695f2ad725.png)
https://user-images.githubusercontent.com/15199528/129582124-4768b006-00dc-4e6c-8bfb-8b28d7bbf5b7.mov




