### PR TITLE
[FEATURE] Stabilize pan/zoom when expanding models

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -44,7 +44,7 @@
     "preact": "8.x",
     "research": "git+https://github.com/uncharted-aske/research.git#aed359c844a6b9c6c6db6100190b9b9d2566e9e2",
     "sigma": "1.2.1",
-    "svg-flowgraph": "^0.4.0",
+    "svg-flowgraph": "^0.4.6",
     "tiny-emitter": "^2.1.0",
     "tweakpane": "^1.5.8",
     "vue": "^2.6.12",

--- a/client/src/types/typesGraphs.ts
+++ b/client/src/types/typesGraphs.ts
@@ -8,6 +8,7 @@ export interface SVGRendererOptionsInterface {
   edgeControlOffset?: number,
   useMinimap?: boolean,
   useZoom?: boolean,
+  useStableZoomPan?: boolean, // false by default. Zoom/Pan remains stable on render changes
   addons?: any
 }
 

--- a/client/src/views/Models/components/Graphs/GlobalGraph.vue
+++ b/client/src/views/Models/components/Graphs/GlobalGraph.vue
@@ -77,6 +77,7 @@
         renderMode: 'basic',
         useEdgeControl: false,
         useZoom: true,
+        useStableZoomPan: true,
         useMinimap: false,
         addons: [expandCollapse, highlight],
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6246,10 +6246,10 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-svg-flowgraph@^0.4.0:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/svg-flowgraph/-/svg-flowgraph-0.4.4.tgz#32b84a3f9c13b87a0296222934c3de9a59d2bd00"
-  integrity sha512-bE1WzYRJYlz6pV7O5V784N8igGeZ2wt5RXM8RtyN+3NNKoCQgemp4Vg53HQ8xeuCuoT6KKL2vRePMnLKT34mGw==
+svg-flowgraph@^0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/svg-flowgraph/-/svg-flowgraph-0.4.6.tgz#3edd219470fb797b187574d06dba0efb2e64661b"
+  integrity sha512-ZNWGQassAKBerDeSJVLocwhauxeMmQbUnMlOdzEj/rfPO/f2dkIXEeoNL3zQ92qO9G/Fi4IPXiwUkU09JlX/iQ==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
### Description
Stabilize the pan/zoom of the model graph renderer on data/layout changes.

### Changes
- Upgrade svg-flowgraph
- Add pan/zoom stabilize option to SVGRenderer's option type
- Set pan/zoom stabilization to true on EPIRenderer

### Considerations
- As the whole graph gets relayed out after each expansion sometimes the node expansion selected gets moved outside of the users field of view. This happens mostly with groups containing many nodes/incoming/outgoing edges 

### Testing
- yarn install required

### Artifacts
https://user-images.githubusercontent.com/15199528/129633793-3eb6f7e6-465e-44b5-85c5-3a7b2b6ee6b1.mov

