### PR TITLE
Put coordination among panels back

### DIFF
--- a/client/src/views/Simulation/components/ModelPanel.vue
+++ b/client/src/views/Simulation/components/ModelPanel.vue
@@ -97,10 +97,12 @@
 
     onNodeClick (selected: Graph.GraphNodeInterface): void {
       this.setSelectedNodes([{ model: this.model.id, node: selected.label }]);
+      this.$emit('highlight', selected.label);
     }
 
     onBackgroundClick (): void {
       this.setSelectedNodes([]);
+      this.$emit('highlight', '');
     }
 
     onNodeDblClick (selected: Graph.GraphNodeInterface): void {


### PR DESCRIPTION
**What**

- For some reason, we lost the coordination among panels (probably some regression issue)

![image](https://user-images.githubusercontent.com/10552785/129747745-3be7af1c-d4c7-472f-85dd-8d306a327d5c.png)

**Testing**

- Open a model.
- Open the simulation space.
- Add parameters and run the model.
- Click on one of the nodes in the graph.
