### PR TITLE
Fix incorrect graph type crash in models view

### DIFF
--- a/client/src/store/modules/model.ts
+++ b/client/src/store/modules/model.ts
@@ -25,7 +25,17 @@ const actions: ActionTree<Model.State, any> = {
 const getters: GetterTree<Model.State, any> = {
   getModelsList: state => state.modelsList,
   getSelectedModelIds: state => [...state.selectedModelIds],
-  getSelectedModelGraphType: state => state.selectedModelGraphType,
+  getSelectedModelGraphType: (state, getters) => {
+    if (state.selectedModelIds.size === 1) {
+      const modelGraphTypeList = state.modelsList
+        .find(model => model.id === getters.getSelectedModelIds[0])?.modelGraph
+        .map(modelGraph => modelGraph.type);
+      if (modelGraphTypeList?.length && !modelGraphTypeList.includes(state.selectedModelGraphType)) {
+        return modelGraphTypeList[0];
+      }
+    }
+    return state.selectedModelGraphType;
+  },
   getCountComputationalModels: (state): number => state.modelsList.length,
   getModelsLayout: state => state.modelsLayout,
 };


### PR DESCRIPTION
Fixes crash when attempting to open `CHIME_SIR` from a fresh state due to incorrect assumed graph type.

To test, from a fresh state, opening `SimpleSIR_metadata`, `CHIME_SIR`, and `SimpleChime+` model views should not result in any errors (either visible or in console). The correct graph type should be used for `CHIME_SIR` and `SimpleChime+`. Graph type switching should be unaffected in the `SimpleSIR_metadata` model.