### PR TITLE
Add mock Donu compute error endpoint

### DIFF
--- a/client/src/services/DonuService.ts
+++ b/client/src/services/DonuService.ts
@@ -393,13 +393,17 @@ export const computeDonuModelSimulationError = async (
     interpolationFn(measure.predicted.times, measure.observed.times, measure.observed.values);
 
     // Compute errors over points within a measure
-    const errorIndividual: number[] = [];
+    const errorIndividual = {
+      values: [],
+      times: [],
+    };
     for (let i = 0; i < measure.predicted.times.length; i++) {
       const norm = errorFn([measure.observed.values[i] - measure.predicted.values[i]]);
-      errorIndividual.push(norm);
+      errorIndividual.values.push(norm);
+      errorIndividual.times.push(measure.predicted.times[i]);
     }
     // Compute total error of the measure using an average over individual point errors
-    const errorMeasureTotal = errorIndividual.reduce((a, b) => a + b, 0) / errorIndividual.length;
+    const errorMeasureTotal = errorIndividual.values.reduce((a, b) => a + b, 0) / errorIndividual.values.length;
     measureErrors.push({
       uid: measure.uid,
       errorIndividual,

--- a/client/src/types/typesDonu.ts
+++ b/client/src/types/typesDonu.ts
@@ -131,7 +131,10 @@ type Measure = {
 
 type MeasureError = {
   uid: string,
-  errorIndividual: number[],
+  errorIndividual: {
+    times: number[],
+    values: number[],
+  },
   errorTotal: number,
 };
 

--- a/client/src/types/typesDonu.ts
+++ b/client/src/types/typesDonu.ts
@@ -65,6 +65,35 @@ type ModelDefinition = {
   type: Type;
 }
 
+type Measure = {
+  uid: string,
+  predicted: {
+    times: number[],
+    values: number[]
+  },
+  observed: {
+    times: number[],
+    values: number[],
+  }
+};
+
+type MeasureError = {
+  uid: string,
+  errorIndividual: {
+    times: number[],
+    values: number[],
+  },
+  errorTotal: number,
+};
+
+enum ErrorModelTypes {
+  L2 = 'L2',
+}
+
+enum InterpolationModelTypes {
+  Linear = 'linear',
+}
+
 // TO-DO: Export GroMEt type from research/gromet/tools/types/GroMEt
 type ModelGraph = any;
 
@@ -73,6 +102,11 @@ type SimulationResponse = {
   values: {
     [key: string]: number[],
   }
+}
+
+type ComputeErrorResponse = {
+  measures: MeasureError,
+  errorTotal: number,
 }
 
 type RequestParameters = {
@@ -108,42 +142,14 @@ type ResponseResult =
   ModelGraph |
   ModelDefinition |
   ModelDefinition[] |
-  SimulationResponse
+  SimulationResponse |
+  ComputeErrorResponse
 ;
 
 type Response = {
   error?: string,
   result?: ResponseResult,
   status?: ResponseStatus,
-}
-
-type Measure = {
-  uid: string,
-  predicted: {
-    times: number[],
-    values: number[]
-  },
-  observed: {
-    times: number[],
-    values: number[],
-  }
-};
-
-type MeasureError = {
-  uid: string,
-  errorIndividual: {
-    times: number[],
-    values: number[],
-  },
-  errorTotal: number,
-};
-
-enum ErrorModelTypes {
-  L2 = 'L2',
-}
-
-enum InterpolationModelTypes {
-  Linear = 'linear',
 }
 
 export {

--- a/client/src/types/typesDonu.ts
+++ b/client/src/types/typesDonu.ts
@@ -117,6 +117,32 @@ type Response = {
   status?: ResponseStatus,
 }
 
+type Measure = {
+  uid: string,
+  predicted: {
+    times: number[],
+    values: number[]
+  },
+  observed: {
+    times: number[],
+    values: number[],
+  }
+};
+
+type MeasureError = {
+  uid: string,
+  errorIndividual: number[],
+  errorTotal: number,
+};
+
+enum ErrorModelTypes {
+  L2 = 'L2',
+}
+
+enum InterpolationModelTypes {
+  Linear = 'linear',
+}
+
 export {
   DataSource,
   Metadata,
@@ -133,4 +159,8 @@ export {
   SimulationResponse,
   Type,
   SimulationType,
+  Measure,
+  MeasureError,
+  ErrorModelTypes,
+  InterpolationModelTypes,
 };

--- a/client/src/utils/ErrorModelsUtil.ts
+++ b/client/src/utils/ErrorModelsUtil.ts
@@ -1,0 +1,6 @@
+export const L2Norm = (x: number[]): number => {
+  // See: https://mathworld.wolfram.com/L2-Norm.html
+  return Math.sqrt(x.reduce((acc, val) => {
+    return acc + Math.abs(val) ** 2;
+  }, 0));
+};

--- a/client/src/utils/InterpolationModelsUtil.ts
+++ b/client/src/utils/InterpolationModelsUtil.ts
@@ -1,0 +1,35 @@
+export const linearInterpolation = (xInterp: number, x: number[], y: number[]): [number, number] => {
+  // See: https://en.wikipedia.org/wiki/Linear_interpolation
+  const len = x.length;
+  if (xInterp < x[0]) {
+    return [y[0] + (xInterp - x[0]) * ((y[1] - y[0]) / (x[1] - x[0])), -1];
+  } else if (xInterp > x[len - 1]) {
+    return [y[len - 1] + (xInterp - x[len - 1]) * ((y[len - 1] - y[len - 2]) / (x[len - 1] - x[len - 2])), len - 1];
+  }
+  let i = 0;
+  while (i < x.length) {
+    if (x[i] === xInterp) {
+      return [y[i], i];
+    }
+    if (x[i] <= xInterp && xInterp < x[i + 1]) {
+      return [y[i] + (xInterp - x[i]) * ((y[i + 1] - y[i]) / (x[i + 1] - x[i])), i];
+    }
+    i++;
+  }
+};
+
+// Utility function to linearly interpolate a set of points
+// NOTE: All arrays are assumed to be sorted in ascending order
+export const linearInterpolations = (xInterps: number[], x: number[], y: number[]): void => {
+  let i = 0;
+  while (i < xInterps.length) {
+    // TODO: Searching for the index to interpolate within each loop is highly inefficient
+    // however it is conceptually easier to understand
+    const [yInterp, interpIdx] = linearInterpolation(xInterps[i], x, y);
+    if (x[interpIdx] !== xInterps[i]) {
+      x.splice(interpIdx + 1, 0, xInterps[i]);
+      y.splice(interpIdx + 1, 0, yInterp);
+    }
+    i++;
+  }
+};


### PR DESCRIPTION
### Description
Add mock Donu compute error endpoint. See Observable Notebook for understanding inputs/outputs: https://observablehq.com/d/f2195229ecf14e0c

### Changes
- Add linear interpolation model
- Add L2 error model
- Add mocked Donu compute error function

### Considerations
- Endpoint reflects the proposed functionality layed out by @liunelson 

### Testing
- The Observable notebook can be used for easier understanding. However you can also attach the compute error function to `window` with `window.computeDonuModelSimulationError = computeDonuModelSimulationError` and then test in browser. 

### Artifacts
- https://observablehq.com/d/f2195229ecf14e0c

