### PR TITLE
Remove aggregated version of the Covid19 gromet

### DIFF
--- a/client/src/services/DonuService.ts
+++ b/client/src/services/DonuService.ts
@@ -1,6 +1,5 @@
 import { GroMEt2Graph } from 'research/gromet/tools/parser/GroMEt2Graph';
 import * as MARM_MODEL_AGGREGATED from '@/static/gromets/emmaa_aggregated/marm_model_gromet_2021-06-28-17-07-14_graph_agg_rev_rategroups.json';
-import * as COVID_MODEL_AGGREGATED from '@/static/gromets/emmaa_aggregated/covid19_inflammasome_gromet_2021-08-17-17-47-36_agg_rev_rategroups.json';
 
 import * as Donu from '@/types/typesDonu';
 import * as Model from '@/types/typesModel';
@@ -132,9 +131,6 @@ export const fetchDonuModels = async (): Promise<Model.Model[]> => {
       if (model.source.model === 'marm_model_gromet_2021-06-28-17-07-14.json' && model.type === Donu.Type.GROMET_PNC) {
         // HACK: Use aggregated marm model as visual graph
         model.graph = MARM_MODEL_AGGREGATED;
-      }
-      if (model.source.model === 'covid19_inflammasome_gromet_2021-08-17-17-47-36.json' && model.type === Donu.Type.GROMET_PNC) {
-        model.graph = COVID_MODEL_AGGREGATED;
       }
     });
 


### PR DESCRIPTION
**What**

- HMS prefers to display this model in its de-aggregated version since it better conveys the linearity of the model. 
![image](https://user-images.githubusercontent.com/10552785/130272501-a34d1d9d-d7cd-4310-8cb1-d1f2c5d00996.png)
 
**Test**
- Select the COVID-19 gromet