### PR TITLE
Gives more space to the label

### DIFF
--- a/client/src/views/Simulation/components/ParametersPanel.vue
+++ b/client/src/views/Simulation/components/ParametersPanel.vue
@@ -405,6 +405,7 @@
     line-height: 2em;
     margin: 0;
     overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .parameter input {
@@ -416,7 +417,6 @@
     font-weight: bold;
     grid-area: value;
     padding: .25em .5em;
-    width: 5em;
   }
 
   .parameter .btn-group {

--- a/client/src/views/Simulation/components/ParametersPanel.vue
+++ b/client/src/views/Simulation/components/ParametersPanel.vue
@@ -4,7 +4,7 @@
     :style="{
       '--padding': padding + 'px',
       '--parameter-height': parameterHeight + 'px',
-      '--parameter-input': parameterInput + 'px',
+      '--parameter-input': parameterInput + '%',
       '--parameter-action': parameterAction + 'px',
     }"
   >
@@ -106,9 +106,9 @@
     @Action hideParameter;
 
     private padding: number = 5;
-    private parameterHeight: number = 75;
-    private parameterInput: number = 65;
-    private parameterAction: number = 35;
+    private parameterHeight: number = 75; // in pixels
+    private parameterInput: number = 40; // in %
+    private parameterAction: number = 35; // in pixels
     private parameterValues: { [uid: string]: number } = {};
     private someParametersAreInvalid: boolean = false;
 
@@ -236,7 +236,7 @@
       const axisLabelWidth = 40;
       const marginX = {
         // Input button + .parameter padding + axis label padding + axis label width
-        left: (this.parameterInput + (this.padding * 3) + axisLabelWidth),
+        left: ((this.parameterInput / 100 * this.graphWidth()) + (this.padding * 3) + axisLabelWidth),
         // Action button + .parameter padding + axis label padding + axis label width
         right: (this.parameterAction + (this.padding * 3) + axisLabelWidth),
       };


### PR DESCRIPTION
**What**
- Fix #396 

**How**
- Change the width for the parameter label to be **40%**, and update the graph to handle a percentage value instead of fix pixels

**Screenshot**

![Screen Shot 2021-08-20 at 14 13 36](https://user-images.githubusercontent.com/636801/130276472-ba761a36-8b51-4f82-a56e-78a6e3496177.png)
