### PR TITLE
Upgrade svg and uncollapse GrFN by default

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -44,7 +44,7 @@
     "preact": "8.x",
     "research": "git+https://github.com/uncharted-aske/research.git#01ea002e13e6b96aec048bffe0742bbe2f47e37d",
     "sigma": "1.2.1",
-    "svg-flowgraph": "^0.4.0",
+    "svg-flowgraph": "^0.4.6",
     "tiny-emitter": "^2.1.0",
     "tweakpane": "^1.5.8",
     "vue": "^2.6.12",

--- a/client/src/views/Models/components/Graphs/GlobalGraph.vue
+++ b/client/src/views/Models/components/Graphs/GlobalGraph.vue
@@ -163,15 +163,6 @@
       this.renderer.setData(data);
       await this.renderer.render();
 
-      // Collapse top-level boxes by default
-      // HACK: The collapse/expand functions are asynchronous and trying to execute them all at once
-      // seems to create problems with the tracker.
-      const collapsedIds = calcNodesToCollapse(this.layout, this.renderer.layout);
-      if (collapsedIds.length > 0) {
-        collapsedIds.forEach(nextId => this.renderer.collapse(nextId));
-        await this.renderer.render();
-      }
-
       this.dataDecorationChanged();
     }
   }

--- a/client/src/views/Models/components/Graphs/GlobalGraph.vue
+++ b/client/src/views/Models/components/Graphs/GlobalGraph.vue
@@ -17,7 +17,7 @@
   import DagreAdapter from '@/graphs/svg/dagre/adapter';
   import ELKAdapter from '@/graphs/svg/elk/adapter';
   import { /** showTooltip, hideTooltip */ hierarchyFn } from '@/utils/SVGUtil.js'; // TODO: Put tooltips back when we fix the positioning issue
-  import { calculateNodeNeighborhood, constructRootNode, calcNodesToCollapse } from '@/graphs/svg/util.js';
+  import { calculateNodeNeighborhood, constructRootNode } from '@/graphs/svg/util.js';
 
   const DEFAULT_RENDERING_OPTIONS = {
     nodeWidth: 120,


### PR DESCRIPTION
**What**
- Collapsing models by default was causing the model to pan out of the Model panel when opening the Simulation view.

**How**
- Decided to remove the default collapsing of gromet GrFNs since it doesn't add much to the narrative of the demo. 
- I also put back the latest svg lib version.


https://user-images.githubusercontent.com/10552785/130469209-a8843f1a-788c-4c99-8ff7-b9255e23a6a9.mov

