### PR TITLE
Increased margin for Y-axis labels 

### DIFF
--- a/client/src/components/widgets/charts/MultiLinePlot.vue
+++ b/client/src/components/widgets/charts/MultiLinePlot.vue
@@ -34,7 +34,7 @@
       top: 15,
       right: 15,
       bottom: 35,
-      left: 35,
+      left: 55,
     },
   };
 


### PR DESCRIPTION
**What**

- Big hack to increase the left margin for Variable plots in the Variables panel. 
- We probably should convert numbers to 10k format but I didn't get around it.
![image](https://user-images.githubusercontent.com/10552785/130518190-fd434d3e-d71f-4930-a917-0f6592b4d32d.png)
