### PR TITLE
Graph centering

### DIFF
--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -128,6 +128,15 @@ export default class EpiRenderer extends SVGRenderer {
       .attr('color', 'SourceGraphic');
   }
 
+  centerGraph () {
+    const viewBox = (this as any).svgEl.viewBox.baseVal;
+    const centerTranslate = {
+      x: ((this as any).chartSize.width - (this as any).layout.width)  / 2,
+      y: ((this as any).chartSize.height  - (this as any).layout.height) / 2
+    };
+    d3.select((this as any).svgEl).call((this as any).zoom.transform, d3.zoomIdentity.translate(centerTranslate.x, centerTranslate.y));
+  };
+
   renderNode (nodeSelection: d3.Selection<any, any, any, any>): void {
     nodeSelection.each(function () {
       const selection = d3.select(this);

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -128,14 +128,13 @@ export default class EpiRenderer extends SVGRenderer {
       .attr('color', 'SourceGraphic');
   }
 
-  centerGraph () {
-    const viewBox = (this as any).svgEl.viewBox.baseVal;
+  centerGraph (): void {
     const centerTranslate = {
-      x: ((this as any).chartSize.width - (this as any).layout.width)  / 2,
-      y: ((this as any).chartSize.height  - (this as any).layout.height) / 2
+      x: ((this as any).chartSize.width - (this as any).layout.width) / 2,
+      y: ((this as any).chartSize.height - (this as any).layout.height) / 2,
     };
     d3.select((this as any).svgEl).call((this as any).zoom.transform, d3.zoomIdentity.translate(centerTranslate.x, centerTranslate.y));
-  };
+  }
 
   renderNode (nodeSelection: d3.Selection<any, any, any, any>): void {
     nodeSelection.each(function () {

--- a/client/src/views/Models/components/Graphs/GlobalGraph.vue
+++ b/client/src/views/Models/components/Graphs/GlobalGraph.vue
@@ -163,8 +163,6 @@
       data = { nodes: [nodesHierarchy], edges: data.edges };
 
       this.renderer.setData(data);
-      await this.renderer.render();
-      this.renderer.enableDrag(true);
 
       // Collapse top-level boxes by default
       // HACK: The collapse/expand functions are asynchronous and trying to execute them all at once
@@ -172,11 +170,11 @@
       const collapsedIds = calcNodesToCollapse(this.layout, this.renderer.layout);
       if (collapsedIds.length > 0) {
         collapsedIds.forEach(nextId => this.renderer.collapse(nextId));
-        await this.renderer.render();
-        this.renderer.enableDrag(true);
-        this.renderer.centerGraph();
       }
 
+      await this.renderer.render();
+      this.renderer.centerGraph();
+      this.renderer.enableDrag(true);
       this.dataDecorationChanged();
     }
   }

--- a/client/src/views/Models/components/Graphs/GlobalGraph.vue
+++ b/client/src/views/Models/components/Graphs/GlobalGraph.vue
@@ -9,7 +9,7 @@
   import Component from 'vue-class-component';
   import { Prop, Watch } from 'vue-property-decorator';
 
-  import { expandCollapse, highlight, panZoom } from 'svg-flowgraph';
+  import { expandCollapse, highlight } from 'svg-flowgraph';
 
   import { GraphInterface, SubgraphInterface, SubgraphNodeInterface, GraphLayoutInterfaceType } from '@/types/typesGraphs';
 

--- a/client/src/views/Models/components/Graphs/GlobalGraph.vue
+++ b/client/src/views/Models/components/Graphs/GlobalGraph.vue
@@ -9,7 +9,7 @@
   import Component from 'vue-class-component';
   import { Prop, Watch } from 'vue-property-decorator';
 
-  import { expandCollapse, highlight } from 'svg-flowgraph';
+  import { expandCollapse, highlight, nodeDrag } from 'svg-flowgraph';
 
   import { GraphInterface, SubgraphInterface, SubgraphNodeInterface, GraphLayoutInterfaceType } from '@/types/typesGraphs';
 
@@ -96,7 +96,7 @@
         useZoom: true,
         useStableZoomPan: true,
         useMinimap: false,
-        addons: [expandCollapse, highlight],
+        addons: [expandCollapse, highlight, nodeDrag],
       });
 
       this.renderer.setCallback('nodeDblClick', (evt, node) => {
@@ -109,7 +109,9 @@
           } else {
             this.renderer.collapse(id);
           }
-          this.renderer.render();
+          this.renderer.render().then(() => {
+              this.renderer.enableDrag(true);
+          });
         }
 
         this.$emit('node-dblclick', node.datum().data);
@@ -162,6 +164,7 @@
 
       this.renderer.setData(data);
       await this.renderer.render();
+      this.renderer.enableDrag(true);
 
       // Collapse top-level boxes by default
       // HACK: The collapse/expand functions are asynchronous and trying to execute them all at once
@@ -170,6 +173,7 @@
       if (collapsedIds.length > 0) {
         collapsedIds.forEach(nextId => this.renderer.collapse(nextId));
         await this.renderer.render();
+        this.renderer.enableDrag(true);
         this.renderer.centerGraph();
       }
 


### PR DESCRIPTION
**What**
- For the demo, we weren't really showing nested graphs so I disabled the automatic collapsing of boxes. However, CHIME models are highly nested so we required to put that back. Collapsing by default was the cause of the graph disappearing. 
- Addressed this issue by implementing a function that centers the graph.
- Put back the automatic collapsing
- Extra:  I also added the ability to drag nodes around that was already available in the SVG lib (although this is not perfect and it doesn't work so well with collapse and expand).
**Testing**

- Open the current CHIME SIR base model
- It should collapse top level boxes by default and get centered properly.

https://user-images.githubusercontent.com/10552785/130765533-95a3aba7-62cc-4be9-bfcb-d4b99ea7b856.mov

