### PR TITLE
Model comparison: mark diff nodes instead

### DIFF
--- a/client/src/graphs/svg/encodings.ts
+++ b/client/src/graphs/svg/encodings.ts
@@ -2,7 +2,7 @@ export abstract class Colors {
   static readonly HIGHLIGHT: string = '#EBCB8B';
   static readonly STROKE: string = '#81A1C1';
   static readonly CONTAINER_CONTROL: string = '#D08770';
-  static readonly NONOVERLAPPING: string = '#81A1C1';
+  static readonly NONOVERLAPPING: string = '#d08770';
 
   static readonly NODES: Record<string, any> = {
     DEFAULT: '#ECEFF4',

--- a/client/src/graphs/svg/encodings.ts
+++ b/client/src/graphs/svg/encodings.ts
@@ -2,7 +2,7 @@ export abstract class Colors {
   static readonly HIGHLIGHT: string = '#EBCB8B';
   static readonly STROKE: string = '#81A1C1';
   static readonly CONTAINER_CONTROL: string = '#D08770';
-  static readonly OVERLAPPING: string = '#81A1C1';
+  static readonly NONOVERLAPPING: string = '#81A1C1';
 
   static readonly NODES: Record<string, any> = {
     DEFAULT: '#ECEFF4',

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -281,11 +281,13 @@ export default class EpiRenderer extends SVGRenderer {
     }
   }
 
-  markNonOverlappingElements (subgraph: SubgraphInterface): void {
+  //HACK: This function actually does the opposite, it marks nodes that are actually different between models. 
+  //Since there are upstream consequences to focus on non-overlapping elements we will keep it this way for now.
+  markOverlappingElements (subgraph: SubgraphInterface): void {
     const chart = (this as any).chart;
     chart?.selectAll('.node-ui').each(function (d) {
-      const isNotOverlapping = subgraph.nodes.some(node => node.id !== d.data.grometID);
-      if (isNotOverlapping && !d.nodes) {
+      const isOverlapping = subgraph.nodes.some(node => node.id === d.data.grometID);
+      if (!isOverlapping && !d.nodes) {
         d3.select(this)
           .select('rect, ellipse')
           .style('fill', Colors.NONOVERLAPPING);

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -281,14 +281,14 @@ export default class EpiRenderer extends SVGRenderer {
     }
   }
 
-  markOverlappingElements (subgraph: SubgraphInterface): void {
+  markNonOverlappingElements (subgraph: SubgraphInterface): void {
     const chart = (this as any).chart;
     chart?.selectAll('.node-ui').each(function (d) {
-      const isOverlapping = subgraph.nodes.some(node => node.id === d.data.grometID);
-      if (isOverlapping) {
+      const isNotOverlapping = subgraph.nodes.some(node => node.id !== d.data.grometID);
+      if (isNotOverlapping && !d.nodes) {
         d3.select(this)
           .select('rect, ellipse')
-          .style('fill', Colors.OVERLAPPING);
+          .style('fill', Colors.NONOVERLAPPING);
       }
     });
   }

--- a/client/src/graphs/svg/renderers/EpiRenderer.ts
+++ b/client/src/graphs/svg/renderers/EpiRenderer.ts
@@ -281,8 +281,8 @@ export default class EpiRenderer extends SVGRenderer {
     }
   }
 
-  //HACK: This function actually does the opposite, it marks nodes that are actually different between models. 
-  //Since there are upstream consequences to focus on non-overlapping elements we will keep it this way for now.
+  // HACK: This function actually does the opposite, it marks nodes that are actually different between models.
+  // Since there are upstream consequences to focus on non-overlapping elements we will keep it this way for now.
   markOverlappingElements (subgraph: SubgraphInterface): void {
     const chart = (this as any).chart;
     chart?.selectAll('.node-ui').each(function (d) {


### PR DESCRIPTION
**What**
- Changed encodings to emphasize diff nodes between models instead
- Changed diff color so it is even more prominent.

![image](https://user-images.githubusercontent.com/10552785/130770092-8e4017ca-f651-4acb-b24a-9536ef4b26ea.png)
