### PR TITLE
Fix issue where GrFNs couldn't get displayed

### DIFF
--- a/client/src/views/Models/components/Graphs/GlobalGraph.vue
+++ b/client/src/views/Models/components/Graphs/GlobalGraph.vue
@@ -163,6 +163,7 @@
       data = { nodes: [nodesHierarchy], edges: data.edges };
 
       this.renderer.setData(data);
+      await this.renderer.render();
 
       // Collapse top-level boxes by default
       // HACK: The collapse/expand functions are asynchronous and trying to execute them all at once
@@ -170,11 +171,12 @@
       const collapsedIds = calcNodesToCollapse(this.layout, this.renderer.layout);
       if (collapsedIds.length > 0) {
         collapsedIds.forEach(nextId => this.renderer.collapse(nextId));
+        await this.renderer.render();
       }
 
-      await this.renderer.render();
-      this.renderer.centerGraph();
       this.renderer.enableDrag(true);
+      this.renderer.centerGraph();
+
       this.dataDecorationChanged();
     }
   }


### PR DESCRIPTION
**What**
- We collapse top-level boxes by default for GrFNs and for some reason, we need to re-render the layout when we do that. I moved the re-rendering out of the condition because I thought we would need to repeat it but we do.

**Test** 
- Open any GrFNs in the app.