### PR TITLE
Update grafer to v0.5.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
     "@uncharted.software/bgraph": "0.3.2",
     "@uncharted.software/facets-core": "^3.1.0",
     "@uncharted.software/facets-plugins": "^3.1.0",
-    "@uncharted.software/grafer": "^0.3.4",
+    "@uncharted.software/grafer": "^0.5.0",
     "@uncharted.software/lex": "^1.0.0",
     "alpha-shape": "^1.0.0",
     "aws-sdk": "^2.866.0",

--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
     "@uncharted.software/bgraph": "0.3.2",
     "@uncharted.software/facets-core": "^3.1.0",
     "@uncharted.software/facets-plugins": "^3.1.0",
-    "@uncharted.software/grafer": "^0.5.0",
+    "@uncharted.software/grafer": "0.5.1",
     "@uncharted.software/lex": "^1.0.0",
     "alpha-shape": "^1.0.0",
     "aws-sdk": "^2.866.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -611,10 +611,10 @@
     lit-element "^2.2.1"
     lit-html "^1.1.2"
 
-"@uncharted.software/grafer@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@uncharted.software/grafer/-/grafer-0.5.0.tgz#0e8a7c560be8ba8a34f0795c08eac89328bff713"
-  integrity sha512-an3+HHDuCoUyFYBNufLvBduJ4etARabkBBd2Z1473MkG/eTIr7GkeoEn245KDkbNO3VH5ZNH7sIMT4Oy/0C0lg==
+"@uncharted.software/grafer@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@uncharted.software/grafer/-/grafer-0.5.1.tgz#521d2e583ff8ef0bb6a9c3b1a32dac2a3ad5ffc7"
+  integrity sha512-vubljZ0FYl3jf731KtRxkxEEuaNX+53/bEEwc4SpeIm3/r6HpiRdUBhB4oiIL1rh74h/EtnpKqHyqJ9Qz8NAxw==
   dependencies:
     "@dekkai/data-source" "^0.2.3"
     "@dekkai/event-emitter" "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -611,18 +611,16 @@
     lit-element "^2.2.1"
     lit-html "^1.1.2"
 
-"@uncharted.software/grafer@^0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@uncharted.software/grafer/-/grafer-0.3.4.tgz#f48664436e5a8563caeffe91925c147a48657275"
-  integrity sha512-4wW6aBhqZzpBfCcCVXMEnfFGA9tIq2g/fYMqRPMDN/JKHl8es8K3BMrXny0s5G9MigoYEjItr3w5x9i0WohaRA==
+"@uncharted.software/grafer@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@uncharted.software/grafer/-/grafer-0.5.0.tgz#0e8a7c560be8ba8a34f0795c08eac89328bff713"
+  integrity sha512-an3+HHDuCoUyFYBNufLvBduJ4etARabkBBd2Z1473MkG/eTIr7GkeoEn245KDkbNO3VH5ZNH7sIMT4Oy/0C0lg==
   dependencies:
     "@dekkai/data-source" "^0.2.3"
     "@dekkai/event-emitter" "^1.1.0"
     chroma-js "^2.1.2"
     dekkai "^0.3.6"
     gl-matrix "^3.3.0"
-    lit-element "^2.5.1"
-    lit-html "^1.4.1"
     picogl "^0.17.7"
     potpack "^1.0.1"
     tweakpane "^1.5.8"
@@ -4025,22 +4023,10 @@ lit-element@^2.2.1:
   dependencies:
     lit-html "^1.1.1"
 
-lit-element@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.5.1.tgz#3fa74b121a6cd22902409ae3859b7847d01aa6b6"
-  integrity sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==
-  dependencies:
-    lit-html "^1.1.1"
-
 lit-html@^1.1.1, lit-html@^1.1.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.3.0.tgz#c80f3cc5793a6dea6c07172be90a70ab20e56034"
   integrity sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q==
-
-lit-html@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.4.1.tgz#0c6f3ee4ad4eb610a49831787f0478ad8e9ae5e0"
-  integrity sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==
 
 live-server@^1.2.1:
   version "1.2.1"
@@ -6246,7 +6232,7 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-svg-flowgraph@^0.4.0:
+svg-flowgraph@^0.4.6:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/svg-flowgraph/-/svg-flowgraph-0.4.6.tgz#3edd219470fb797b187574d06dba0efb2e64661b"
   integrity sha512-ZNWGQassAKBerDeSJVLocwhauxeMmQbUnMlOdzEj/rfPO/f2dkIXEeoNL3zQ92qO9G/Fi4IPXiwUkU09JlX/iQ==


### PR DESCRIPTION
### Description
Update grafer.

### Changes
- Update grafer to v0.5.0 in package.
- Update yarn.lock

### Considerations
- Updating Grafer removes clipping issues experienced when a foreground layer has the same z-index/viewing-frustum as the background layer. 

### Future Work
- Zooming around the graph on a Mac's trackpad is difficult on the new Grafer version - Done in v0.5.1
- Label font on the Rings is difficult to read - Done in v0.5.1

### Testing
- Try out graphs of various sizes. Perform queries etc.

### Artifacts
<img width="1680" alt="Screen Shot 2021-09-08 at 1 53 00 PM" src="https://user-images.githubusercontent.com/15199528/132560069-643b85e2-6f02-4e75-aace-8cdc6a0fbb87.png">

#442 